### PR TITLE
use async request for upload

### DIFF
--- a/learning_loop_node/detector/outbox.py
+++ b/learning_loop_node/detector/outbox.py
@@ -14,9 +14,9 @@ from multiprocessing import Event
 from multiprocessing.synchronize import Event as SyncEvent
 from typing import List, Optional, Tuple, Union
 
+import aiohttp
 import PIL
 import PIL.Image  # type: ignore
-import requests
 from fastapi.encoders import jsonable_encoder
 
 from ..data_classes import Detections
@@ -97,11 +97,11 @@ class Outbox():
         self.log.info('continuous upload started')
         assert self.shutdown_event is not None
         while not self.shutdown_event.is_set():
-            self.upload()
+            await self.upload()
             await asyncio.sleep(5)
         self.log.info('continuous upload ended')
 
-    def upload(self):
+    async def upload(self):
         items = self.get_data_files()
         if not items:
             self.log.debug('No images found to upload')
@@ -113,11 +113,11 @@ class Outbox():
             if self.shutdown_event.is_set():
                 break
             try:
-                self._upload_batch(batch_items)
+                await self._upload_batch(batch_items)
             except Exception:
                 self.log.exception('Could not upload files')
 
-    def _upload_batch(self, items: List[str]):
+    async def _upload_batch(self, items: List[str]):
 
         # NOTE: keys are not relevant for the server, but using a fixed key like 'files'
         # results in a post failure on the first run of the test in a docker environment (WTF)
@@ -127,7 +127,8 @@ class Outbox():
         data += [('files', open(f'{item}/image.jpg', 'rb')) for item in items]
 
         try:
-            response = requests.post(self.target_uri, files=data, timeout=self.UPLOAD_TIMEOUT_S)
+            async with aiohttp.ClientSession() as session:
+                response = await session.post(self.target_uri, data=data, timeout=self.UPLOAD_TIMEOUT_S)
         except Exception:
             self.log.exception('Could not upload images')
             return
@@ -136,21 +137,21 @@ class Outbox():
             for _, file in data:
                 file.close()
 
-        if response.status_code == 200:
+        if response.status == 200:
             self.upload_counter += len(items)
             for item in items:
                 shutil.rmtree(item, ignore_errors=True)
             self.log.info('Uploaded %s images successfully', len(items))
 
-        elif response.status_code == 422:
+        elif response.status == 422:
             if len(items) == 1:
                 self.log.error('Broken content in image: %s\n Skipping.', items[0])
                 shutil.rmtree(items[0], ignore_errors=True)
                 return
 
             self.log.exception('Broken content in batch. Splitting and retrying')
-            self._upload_batch(items[:len(items)//2])
-            self._upload_batch(items[len(items)//2:])
+            await self._upload_batch(items[:len(items)//2])
+            await self._upload_batch(items[len(items)//2:])
         else:
             self.log.error('Could not upload images: %s', response.content)
 

--- a/learning_loop_node/detector/outbox.py
+++ b/learning_loop_node/detector/outbox.py
@@ -80,10 +80,7 @@ class Outbox():
             f.write(image)
 
         if os.path.exists(tmp):
-            try:
-                os.rename(tmp, self.path + '/' + identifier)  # NOTE rename is atomic so upload can run in parallel
-            except OSError:
-                self.log.exception('Could not rename %s to %s', tmp, self.path + '/' + identifier)
+            os.rename(tmp, self.path + '/' + identifier)  # NOTE rename is atomic so upload can run in parallel
         else:
             self.log.error('Could not rename %s to %s', tmp, self.path + '/' + identifier)
 

--- a/learning_loop_node/detector/outbox.py
+++ b/learning_loop_node/detector/outbox.py
@@ -64,7 +64,10 @@ class Outbox():
             detections = Detections()
         if not tags:
             tags = []
-        identifier = datetime.now().isoformat(sep='_', timespec='milliseconds')
+        identifier = datetime.now().isoformat(sep='_', timespec='microseconds')
+        if os.path.exists(self.path + '/' + identifier):
+            self.log.error('Directory with identifier %s already exists', identifier)
+            return
         tmp = f'{GLOBALS.data_folder}/tmp/{identifier}'
         detections.tags = tags
         detections.date = identifier
@@ -77,7 +80,10 @@ class Outbox():
             f.write(image)
 
         if os.path.exists(tmp):
-            os.rename(tmp, self.path + '/' + identifier)  # NOTE rename is atomic so upload can run in parallel
+            try:
+                os.rename(tmp, self.path + '/' + identifier)  # NOTE rename is atomic so upload can run in parallel
+            except OSError:
+                self.log.exception('Could not rename %s to %s', tmp, self.path + '/' + identifier)
         else:
             self.log.error('Could not rename %s to %s', tmp, self.path + '/' + identifier)
 

--- a/learning_loop_node/tests/detector/test_client_communication.py
+++ b/learning_loop_node/tests/detector/test_client_communication.py
@@ -128,11 +128,17 @@ async def test_api_responsive_during_large_upload(test_detector_node: DetectorNo
 
     with open(test_image_path, 'rb') as f:
         image_bytes = f.read()
-    images = [image_bytes] * 50
-    for image in images:
-        test_detector_node.outbox.save(image)
-    await asyncio.sleep(5)
+
+    for _ in range(100):
+        test_detector_node.outbox.save(image_bytes)
+
+    outbox_size_early = len(get_outbox_files(test_detector_node.outbox))
+    await asyncio.sleep(5)  # NOTE: we wait 5 seconds because the continuous upload is running every 5 seconds
 
     # check if api is still responsive
-    response = requests.get(f'http://localhost:{GLOBALS.detector_port}/outbox_mode', timeout=5)
+    response = requests.get(f'http://localhost:{GLOBALS.detector_port}/outbox_mode', timeout=2)
     assert response.status_code == 200
+
+    await asyncio.sleep(5)
+    outbox_size_late = len(get_outbox_files(test_detector_node.outbox))
+    assert outbox_size_early > outbox_size_late > 0, 'The outbox should have been partially emptied.'

--- a/learning_loop_node/tests/detector/test_outbox.py
+++ b/learning_loop_node/tests/detector/test_outbox.py
@@ -52,7 +52,7 @@ async def test_outbox_upload_is_successful(test_outbox: Outbox):
     await asyncio.sleep(1)
     test_outbox.save(get_test_image_binary())
     assert await wait_for_outbox_count(test_outbox, 2)
-    test_outbox.upload()
+    await test_outbox.upload()
     assert await wait_for_outbox_count(test_outbox, 0)
     assert test_outbox.upload_counter == 2
 


### PR DESCRIPTION
- uses `aiohttp` to make uploads in a non-blocking ways
- adds a test that starts an upload of 50 images and tries to make a request
- increases naming precision to microseconds to allow for faster consecutive saves