### PR TITLE
Feature (detector): provide version_control in /about endpoint

### DIFF
--- a/learning_loop_node/detector/rest/about.py
+++ b/learning_loop_node/detector/rest/about.py
@@ -22,4 +22,5 @@ async def get_about(request: Request):
         'state': app.status.state,
         'model_info':  app.detector_logic._model_info,  # pylint: disable=protected-access
         'target_model': app.target_model.version if app.target_model is not None else 'None',
+        'version_control': app.version_control.value,
     }


### PR DESCRIPTION
This PR adds the version_control state to the /about endpoint to simplify the usage. Otherwise we would need to request /about and /model_version regularly.