### PR TITLE
Add identifier to uploaded file names

### DIFF
--- a/learning_loop_node/detector/outbox.py
+++ b/learning_loop_node/detector/outbox.py
@@ -148,7 +148,7 @@ class Outbox():
 
         try:
             async with aiohttp.ClientSession() as session:
-                response = await session.post(self.target_uri, data=data, timeout=aiohttp.ClientTimeout(total=self.UPLOAD_TIMEOUT_S))
+                response = await session.post(self.target_uri, data=data, timeout=self.UPLOAD_TIMEOUT_S)
         except Exception:
             self.log.exception('Could not upload images')
             return

--- a/learning_loop_node/detector/outbox.py
+++ b/learning_loop_node/detector/outbox.py
@@ -148,7 +148,7 @@ class Outbox():
 
         try:
             async with aiohttp.ClientSession() as session:
-                response = await session.post(self.target_uri, data=data, timeout=self.UPLOAD_TIMEOUT_S)
+                response = await session.post(self.target_uri, data=data, timeout=aiohttp.ClientTimeout(total=self.UPLOAD_TIMEOUT_S))
         except Exception:
             self.log.exception('Could not upload images')
             return


### PR DESCRIPTION
There was a major bug where the uploaded files in a batch upload all had the same name. This caused the learning loop to import the same file up to 20 times.