### PR TITLE
Prevent endless loop on engine build

### DIFF
--- a/learning_loop_node/detector/detector_logic.py
+++ b/learning_loop_node/detector/detector_logic.py
@@ -14,7 +14,8 @@ class DetectorLogic():
     def __init__(self, model_format: str) -> None:
         self.model_format: str = model_format
         self._model_info: Optional[ModelInformation] = None
-        self._remaining_init_retries: int = 2
+
+        self._remaining_init_attempts: int = 2
 
     async def soft_reload(self):
         self._model_info = None
@@ -38,12 +39,12 @@ class DetectorLogic():
         try:
             self.init()
             logging.info('Successfully loaded model %s', self._model_info)
-            self._remaining_init_retries = 2
+            self._remaining_init_attempts = 2
         except Exception:
-            self._remaining_init_retries -= 1
+            self._remaining_init_attempts -= 1
             self._model_info = None
-            logging.error('Could not init model %s. Retries left: %s', self._model_info, self._remaining_init_retries)
-            if self._remaining_init_retries == 0:
+            logging.error('Could not init model %s. Retries left: %s', self._model_info, self._remaining_init_attempts)
+            if self._remaining_init_attempts == 0:
                 raise NodeNeedsRestartError('Could not init model') from None
             raise
 

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -3,6 +3,7 @@ import contextlib
 import os
 import shutil
 import subprocess
+import sys
 from dataclasses import asdict
 from datetime import datetime
 from threading import Thread
@@ -23,6 +24,7 @@ from ..globals import GLOBALS
 from ..helpers import environment_reader
 from ..node import Node
 from .detector_logic import DetectorLogic
+from .exceptions import NodeNeedsRestartError
 from .inbox_filter.relevance_filter import RelevanceFilter
 from .outbox import Outbox
 from .rest import about as rest_about
@@ -170,13 +172,13 @@ class DetectorNode(Node):
 
         # simulate startup
         await self.detector_logic.soft_reload()
-        self.detector_logic.load_model()
+        self.detector_logic.load_model_info_and_init_model()
         self.operation_mode = OperationMode.Idle
 
     async def on_startup(self) -> None:
         try:
             self.outbox.ensure_continuous_upload()
-            self.detector_logic.load_model()
+            self.detector_logic.load_model_info_and_init_model()
         except Exception:
             self.log.exception("error during 'startup'")
         self.operation_mode = OperationMode.Idle
@@ -318,9 +320,12 @@ class DetectorNode(Node):
                 self.log.debug('not checking for updates; no target model selected')
                 return
 
-            current_version = self.detector_logic._model_info.version if self.detector_logic._model_info is not None else None  # pylint: disable=protected-access
+            if self.detector_logic.is_initialized:
+                current_version = self.detector_logic.model_info.version
+            else:
+                current_version = None
 
-            if not self.detector_logic.is_initialized or self.target_model.version != current_version:
+            if current_version != self.target_model.version:
                 self.log.info('Current model "%s" needs to be updated to %s',
                               current_version or "-", self.target_model.version)
 
@@ -346,7 +351,10 @@ class DetectorNode(Node):
                     self.log.info('Updated symlink for model to %s', os.readlink(model_symlink))
 
                     try:
-                        self.detector_logic.load_model()
+                        self.detector_logic.load_model_info_and_init_model()
+                    except NodeNeedsRestartError:
+                        self.log.error('Node needs restart')
+                        sys.exit(0)
                     except Exception:
                         self.log.exception('Could not load model, will retry download on next check')
                         shutil.rmtree(target_model_folder, ignore_errors=True)

--- a/learning_loop_node/detector/exceptions.py
+++ b/learning_loop_node/detector/exceptions.py
@@ -1,0 +1,7 @@
+
+
+class NodeNeedsRestartError(Exception):
+    '''
+    NodeNeedsRestartError is raised when the node needs to be restarted.
+    This is e.g. the case when the GPU is not available anymore.
+    '''


### PR DESCRIPTION
retry model init only a limited number of times before restarting the node.

Also: don't raise an exception if no model is loaded.. this is fine when there is no deployment target