### PR TITLE
Handle model download error

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ You can configure connection to our Learning Loop by specifying the following en
 | LOOP_USERNAME            | USERNAME     | Learning Loop user name                                      | all besides Detector      |
 | LOOP_PASSWORD            | PASSWORD     | Learning Loop password                                       | all besides Detector      |
 | LOOP_SSL_CERT_PATH       | -            | Path to the SSL certificate                                  | all (opt.)                |
-| LOOP_ORGANIZATION        | ORGANIZATION | Organization name                                            | Detector                  |
-| LOOP_PROJECT             | PROJECT      | Project name                                                 | Detector (opt.)           |
+| LOOP_ORGANIZATION        | ORGANIZATION | Organization ID                                              | Detector                  |
+| LOOP_PROJECT             | PROJECT      | Project ID                                                   | Detector (opt.)           |
 | MIN_UNCERTAIN_THRESHOLD  | -            | smallest confidence (float) at which auto-upload will happen | Detector (opt.)           |
 | MAX_UNCERTAIN_THRESHOLD  | -            | largest confidence (float) at which auto-upload will happen  | Detector (opt.)           |
 | INFERENCE_BATCH_SIZE     | -            | Batch size of trainer when calculating detections            | Trainer (opt.)            |
@@ -32,6 +32,8 @@ You can configure connection to our Learning Loop by specifying the following en
 | KEEP_OLD_TRAININGS       | -            | Do not delete old trainings (set to 1)                       | Trainer (opt.)            |
 | TRAINER_IDLE_TIMEOUT_SEC | -            | Automatically shutdown trainer after timeout (in seconds)    | Trainer (opt.)            |
 | USE_BACKDOOR_CONTROLS    | -            | Always enable backdoor controls (set to 1)                   | Trainer / Detector (opt.) |
+
+Note that organization and project IDs are always lower case and may differ from the names in the Learning Loop which can have uppercase letters.
 
 #### Testing
 

--- a/learning_loop_node/data_exchanger.py
+++ b/learning_loop_node/data_exchanger.py
@@ -143,7 +143,7 @@ class DataExchanger():
         logging.info('Downloading model data for uuid %s from the loop to %s..', model_uuid, target_folder)
 
         path = f'/{context.organization}/projects/{context.project}/models/{model_uuid}/{model_format}/file'
-        response = await self.loop_communicator.get(path, requires_login=False)
+        response = await self.loop_communicator.get(path, requires_login=False, timeout=60*10)
         if response.status_code != 200:
             decoded_content = response.content.decode('utf-8')
             logging.error('could not download loop/%s: %s, content: %s', path,


### PR DESCRIPTION
When a model was not downloaded fast enough this resulted in an empty model directory. 
As only the existence of the folder waas checked, the node tried to build the negine but obviously failed. 
this resulted in an endless loop.

- handle errors when downloading a model 
- wait longer for model to download