### PR TITLE
Detector communication via rest

### DIFF
--- a/base_node.dockerfile
+++ b/base_node.dockerfile
@@ -29,3 +29,6 @@ RUN if [ "$INSTALL_DEV" = 'true' ]; then poetry install -vvv --no-root; else poe
 
 # while development this will be mounted but in deployment we need the latest code baked into the image
 ADD ./learning_loop_node /usr/local/lib/python3.11/site-packages/learning_loop_node
+
+# Overwrite the entrypoint to bash
+ENTRYPOINT ["/bin/bash"]

--- a/base_node.dockerfile
+++ b/base_node.dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && \
 
 WORKDIR /app/
 
+# delete everything in /app
+RUN rm -rf /app/*
+
 RUN python3 -m pip install --upgrade pip
 
 # We use Poetry for dependency management (recommended way to install it)

--- a/base_node.dockerfile
+++ b/base_node.dockerfile
@@ -1,4 +1,4 @@
-FROM zauberzeug/nicegui:1.2.13
+FROM zauberzeug/nicegui:2.23.3
 
 RUN apt-get update && \
     apt-get install -y \

--- a/learning_loop_node/annotation/annotator_node.py
+++ b/learning_loop_node/annotation/annotator_node.py
@@ -35,7 +35,7 @@ class AnnotatorNode(Node):
             return self.tool.logout_user(sid)
 
     async def _handle_user_input(self, user_input_dict: Dict) -> str:
-        if not self._sio_client or not self._sio_client.connected:
+        if not self.sio_client or not self.sio_client.connected:
             raise ConnectionError('SocketIO client is not connected')
 
         user_input = from_dict(data_class=UserInput, data=user_input_dict)
@@ -53,9 +53,9 @@ class AnnotatorNode(Node):
             raise
 
         if tool_result.annotation:
-            await self._sio_client.call('update_segmentation_annotation', (user_input.data.context.organization,
-                                                                           user_input.data.context.project,
-                                                                           jsonable_encoder(asdict(tool_result.annotation))), timeout=30)
+            await self.sio_client.call('update_segmentation_annotation', (user_input.data.context.organization,
+                                                                          user_input.data.context.project,
+                                                                          jsonable_encoder(asdict(tool_result.annotation))), timeout=30)
         return tool_result.svg
 
     def reset_history(self, frontend_id: str) -> None:
@@ -69,7 +69,7 @@ class AnnotatorNode(Node):
 
     async def send_status(self):
 
-        if not self._sio_client or not self._sio_client.connected:
+        if not self.sio_client or not self.sio_client.connected:
             raise ConnectionError('SocketIO client is not connected')
 
         status = AnnotationNodeStatus(
@@ -82,7 +82,7 @@ class AnnotatorNode(Node):
         self.log_status_on_change(status.state.value if status.state else 'None', status)
 
         try:
-            result = await self._sio_client.call('update_annotation_node', jsonable_encoder(asdict(status)), timeout=10)
+            result = await self.sio_client.call('update_annotation_node', jsonable_encoder(asdict(status)), timeout=10)
         except Exception:
             self.socket_connection_broken = True
             self.log.exception('Error for updating:')

--- a/learning_loop_node/annotation/annotator_node.py
+++ b/learning_loop_node/annotation/annotator_node.py
@@ -18,7 +18,7 @@ from .annotator_logic import AnnotatorLogic
 class AnnotatorNode(Node):
 
     def __init__(self, name: str, annotator_logic: AnnotatorLogic, uuid: Optional[str] = None):
-        super().__init__(name, uuid, 'annotation_node')
+        super().__init__(name, uuid=uuid, node_type='annotation_node')
         self.tool = annotator_logic
         self.histories: Dict = {}
         annotator_logic.init(self)

--- a/learning_loop_node/data_classes/__init__.py
+++ b/learning_loop_node/data_classes/__init__.py
@@ -1,17 +1,43 @@
 from .annotations import AnnotationData, SegmentationAnnotation, ToolOutput, UserInput
-from .detections import (BoxDetection, ClassificationDetection, Detections, Observation, Point, PointDetection,
-                         SegmentationDetection, Shape)
-from .general import (AboutResponse, AnnotationNodeStatus, Category, Context, DetectionStatus, ErrorConfiguration,
-                      ModelInformation, ModelVersionResponse, NodeState, NodeStatus)
+from .detections import (
+    BoxDetection,
+    ClassificationDetection,
+    Detections,
+    Observation,
+    Point,
+    PointDetection,
+    SegmentationDetection,
+    Shape,
+)
+from .general import (
+    AboutResponse,
+    AnnotationNodeStatus,
+    Category,
+    Context,
+    DetectorStatus,
+    ErrorConfiguration,
+    ModelInformation,
+    ModelVersionResponse,
+    NodeState,
+    NodeStatus,
+)
 from .image_metadata import ImageMetadata, ImagesMetadata
 from .socket_response import SocketResponse
-from .training import Errors, PretrainedModel, Training, TrainingError, TrainingOut, TrainingStateData, TrainingStatus
+from .training import (
+    Errors,
+    PretrainedModel,
+    Training,
+    TrainingError,
+    TrainingOut,
+    TrainingStateData,
+    TrainingStatus,
+)
 
 __all__ = [
     'AboutResponse', 'AnnotationData', 'SegmentationAnnotation', 'ToolOutput', 'UserInput',
     'BoxDetection', 'ClassificationDetection', 'ImageMetadata', 'Observation', 'Point', 'PointDetection',
     'SegmentationDetection', 'Shape', 'Detections',
-    'AnnotationNodeStatus', 'Category', 'Context', 'DetectionStatus', 'ErrorConfiguration',
+    'AnnotationNodeStatus', 'Category', 'Context', 'DetectorStatus', 'ErrorConfiguration',
     'ModelInformation', 'NodeState', 'NodeStatus', 'ModelVersionResponse', 'ImagesMetadata',
     'SocketResponse',
     'Errors', 'PretrainedModel', 'Training',

--- a/learning_loop_node/data_classes/general.py
+++ b/learning_loop_node/data_classes/general.py
@@ -148,8 +148,8 @@ class NodeState(str, Enum):
 class NodeStatus():
     id: str
     name: str
-    state: Optional[NodeState] = NodeState.Online
-    uptime: Optional[int] = 0
+    state: NodeState = NodeState.Online
+    uptime: int = 0
     errors: Dict = field(default_factory=dict)
     capabilities: List[str] = field(default_factory=list)
 
@@ -175,14 +175,13 @@ class AnnotationNodeStatus(NodeStatus):
 
 
 @dataclass(**KWONLY_SLOTS)
-class DetectionStatus():
-    id: str
+class DetectorStatus():
+    uuid: str
     name: str
+    state: NodeState
+    uptime: int
     model_format: str
-
-    state: Optional[NodeState] = None
-    errors: Optional[Dict] = None
-    uptime: Optional[int] = None
-    current_model: Optional[str] = None
-    target_model: Optional[str] = None
-    operation_mode: Optional[str] = None
+    current_model: Optional[str]
+    target_model: Optional[str]
+    errors: Dict
+    operation_mode: str

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -13,8 +13,17 @@ from dacite import from_dict
 from fastapi.encoders import jsonable_encoder
 from socketio import AsyncClient
 
-from ..data_classes import (AboutResponse, Category, Context, DetectionStatus, ImageMetadata, ImagesMetadata,
-                            ModelInformation, ModelVersionResponse, Shape)
+from ..data_classes import (
+    AboutResponse,
+    Category,
+    Context,
+    DetectionStatus,
+    ImageMetadata,
+    ImagesMetadata,
+    ModelInformation,
+    ModelVersionResponse,
+    Shape,
+)
 from ..data_classes.socket_response import SocketResponse
 from ..data_exchanger import DataExchanger, DownloadError
 from ..enums import OperationMode, VersionMode
@@ -409,7 +418,7 @@ class DetectorNode(Node):
             Exception: If the communication with the Learning Loop failed.
         """
 
-        if not self.sio_client.connected:
+        if not self._sio_client or not self._sio_client.connected:
             self.log.info('Status sync failed: not connected')
             raise Exception('Status sync failed: not connected')
 
@@ -436,7 +445,7 @@ class DetectorNode(Node):
 
         # NOTE: sending organization and project is no longer required!
         try:
-            response = await self.sio_client.call('update_detector', (self.organization, self.project, jsonable_encoder(asdict(status))))
+            response = await self._sio_client.call('update_detector', (self.organization, self.project, jsonable_encoder(asdict(status))))
         except TimeoutError:
             self.socket_connection_broken = True
             self.log.exception('TimeoutError for sending status update (will try to reconnect):')

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -46,7 +46,7 @@ from .rest import upload as rest_upload
 class DetectorNode(Node):
 
     def __init__(self, name: str, detector: DetectorLogic, uuid: Optional[str] = None, use_backdoor_controls: bool = False) -> None:
-        super().__init__(name, uuid, 'detector', False)
+        super().__init__(name, uuid=uuid, node_type='detector', needs_login=False, needs_sio=False)
         self.detector_logic = detector
         self.organization = environment_reader.organization()
         self.project = environment_reader.project()

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -72,7 +72,8 @@ class DetectorNode(Node):
         self.target_model: Optional[ModelInformation] = None
         self.loop_deployment_target: Optional[ModelInformation] = None
 
-        self._regular_status_sync_cycles: int = 1  # sync status every 6 cycles (6*10s = 1min)
+        self._regular_status_sync_cycles: int = int(os.environ.get('SYNC_CYCLES', '6'))
+        """sync status every 6 cycles (6*10s = 1min)"""
         self._repeat_cycles_to_next_sync: int = 0
 
         self.include_router(rest_detect.router, tags=["detect"])

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -17,14 +17,13 @@ from ..data_classes import (
     AboutResponse,
     Category,
     Context,
-    DetectionStatus,
+    DetectorStatus,
     ImageMetadata,
     ImagesMetadata,
     ModelInformation,
     ModelVersionResponse,
     Shape,
 )
-from ..data_classes.socket_response import SocketResponse
 from ..data_exchanger import DataExchanger, DownloadError
 from ..enums import OperationMode, VersionMode
 from ..globals import GLOBALS
@@ -73,6 +72,9 @@ class DetectorNode(Node):
         self.target_model: Optional[ModelInformation] = None
         self.loop_deployment_target: Optional[ModelInformation] = None
 
+        self._regular_status_sync_cycles: int = 1  # sync status every 6 cycles (6*10s = 1min)
+        self._repeat_cycles_to_next_sync: int = 0
+
         self.include_router(rest_detect.router, tags=["detect"])
         self.include_router(rest_upload.router, prefix="")
         self.include_router(rest_mode.router, tags=["operation_mode"])
@@ -83,7 +85,7 @@ class DetectorNode(Node):
         if use_backdoor_controls or os.environ.get('USE_BACKDOOR_CONTROLS', '0').lower() in ('1', 'true'):
             self.include_router(backdoor_controls.router)
 
-        self.setup_sio_server()
+        self._setup_sio_server()
 
     def get_about_response(self) -> AboutResponse:
         return AboutResponse(
@@ -199,13 +201,7 @@ class DetectorNode(Node):
         except Exception:
             self.log.exception("error during 'shutdown'")
 
-    async def on_repeat(self) -> None:
-        try:
-            await self._check_for_update()
-        except Exception:
-            self.log.exception("error during '_check_for_update'")
-
-    def setup_sio_server(self) -> None:
+    def _setup_sio_server(self) -> None:
         """The DetectorNode acts as a SocketIO server. This method sets up the server and defines the event handlers."""
         # pylint: disable=unused-argument
 
@@ -331,96 +327,25 @@ class DetectorNode(Node):
         def connect(sid, environ, auth) -> None:
             self.connected_clients.append(sid)
 
-    async def _check_for_update(self) -> None:
+# ================================== Repeat Cycle, sync and model updates ==================================
+
+    async def on_repeat(self) -> None:
+        """Implementation of the repeat cycle. This method is called every 10 seconds."""
         try:
-            self.log.debug('Current operation mode is %s', self.operation_mode)
-            try:
-                await self.sync_status_with_learning_loop()
-            except Exception:
-                self.log.exception('Sync with learning loop failed (could not check for updates):')
-                return
+            await self._sync_status_with_loop()
+            await self._update_model_if_required()
+        except Exception:
+            self.log.exception("error during '_check_for_update'")
 
-            if self.operation_mode != OperationMode.Idle:
-                self.log.debug('not checking for updates; operation mode is %s', self.operation_mode)
-                return
-
-            self.status.reset_error('update_model')
-            if self.target_model is None:
-                self.log.debug('not checking for updates; no target model selected')
-                return
-
-            if self.detector_logic.model_info is not None:
-                current_version = self.detector_logic.model_info.version
-            else:
-                current_version = None
-
-            if current_version != self.target_model.version:
-                self.log.info('Current model "%s" needs to be updated to %s',
-                              current_version or "-", self.target_model.version)
-
-                with step_into(GLOBALS.data_folder):
-                    model_symlink = 'model'
-                    target_model_folder = f'models/{self.target_model.version}'
-                    if os.path.exists(target_model_folder) and len(os.listdir(target_model_folder)) > 0:
-                        self.log.info('No need to download model %s (already exists)', self.target_model.version)
-                    else:
-                        os.makedirs(target_model_folder, exist_ok=True)
-                        try:
-                            await self.data_exchanger.download_model(target_model_folder,
-                                                                     Context(organization=self.organization,
-                                                                             project=self.project),
-                                                                     self.target_model.id,
-                                                                     self.detector_logic.model_format)
-                            self.log.info('Downloaded model %s', self.target_model.version)
-                        except Exception:
-                            self.log.exception('Could not download model %s', self.target_model.version)
-                            shutil.rmtree(target_model_folder, ignore_errors=True)
-                            return
-                    try:
-                        os.unlink(model_symlink)
-                        os.remove(model_symlink)
-                    except Exception:
-                        pass
-                    os.symlink(target_model_folder, model_symlink)
-                    self.log.info('Updated symlink for model to %s', os.readlink(model_symlink))
-
-                    try:
-                        self.detector_logic.load_model_info_and_init_model()
-                    except NodeNeedsRestartError:
-                        self.log.error('Node needs restart')
-                        sys.exit(0)
-                    except Exception:
-                        self.log.exception('Could not load model, will retry download on next check')
-                        shutil.rmtree(target_model_folder, ignore_errors=True)
-                        return
-                    try:
-                        await self.sync_status_with_learning_loop()
-                    except Exception:
-                        pass
-                    # self.reload(reason='new model installed')
-
-        except Exception as e:
-            self.log.exception('check_for_update failed')
-            msg = e.cause if isinstance(e, DownloadError) else str(e)
-            self.status.set_error('update_model', f'Could not update model: {msg}')
-            try:
-                await self.sync_status_with_learning_loop()
-            except Exception:
-                pass
-
-    async def sync_status_with_learning_loop(self) -> None:
+    async def _sync_status_with_loop(self, force=False) -> None:
         """Sync status of the detector with the Learning Loop.
-        The Learning Loop will respond with the model info of the deployment target.
-        If version_control is set to FollowLoop, the detector will update the target_model.
-        Return if the communication was successful.
+        To avoid too many requests, the status is only synced every 6 cycles (1 minute) unless force is True."""
 
-        Raises:
-            Exception: If the communication with the Learning Loop failed.
-        """
-
-        if not self.sio_client or not self.sio_client.connected:
-            self.log.info('Status sync failed: not connected')
-            raise Exception('Status sync failed: not connected')
+        if not force:
+            self._repeat_cycles_to_next_sync -= 1
+            if self._repeat_cycles_to_next_sync > 0:
+                return
+            self._repeat_cycles_to_next_sync = self._regular_status_sync_cycles
 
         if self.detector_logic.model_info is not None:
             current_model = self.detector_logic.model_info.version
@@ -429,8 +354,8 @@ class DetectorNode(Node):
 
         target_model_version = self.target_model.version if self.target_model else None
 
-        status = DetectionStatus(
-            id=self.uuid,
+        status = DetectorStatus(
+            uuid=self.uuid,
             name=self.name,
             state=self.status.state,
             errors=self.status.errors,
@@ -443,47 +368,126 @@ class DetectorNode(Node):
 
         self.log_status_on_change(status.state or 'None', status)
 
-        # NOTE: sending organization and project is no longer required!
         try:
-            response = await self.sio_client.call('update_detector', (self.organization, self.project, jsonable_encoder(asdict(status))))
-        except TimeoutError:
-            self.socket_connection_broken = True
-            self.log.exception('TimeoutError for sending status update (will try to reconnect):')
-            raise Exception('Status update failed due to timeout') from None
+            response = await self.loop_communicator.post(
+                f'/{self.organization}/projects/{self.project}/detectors', json=jsonable_encoder(asdict(status)))
+        except Exception:
+            self.log.warning('Exception while trying to sync status with loop')
 
-        if not response:
-            self.socket_connection_broken = True
-            self.log.error('Status update failed (will try to reconnect): %s', response)
-            raise Exception('Status update failed: Did not receive a response from the learning loop')
+        if response.status_code != 200:
+            self.log.warning('Status update failed: %s', str(response))
 
-        socket_response = from_dict(data_class=SocketResponse, data=response)
-        if not socket_response.success:
-            self.socket_connection_broken = True
-            self.log.error('Status update failed (will try to reconnect): %s', response)
-            raise Exception(f'Status update failed. Response from learning loop: {response}')
+    async def _update_model_if_required(self) -> None:
+        """Check if a new model is available and update if necessary.
+        The Learning Loop will respond with the model info of the deployment target.
+        If version_control is set to FollowLoop or the chosen target model is not used, 
+        the detector will update the target_model."""
+        try:
+            if self.operation_mode != OperationMode.Idle:
+                self.log.debug('not checking for updates; operation mode is %s', self.operation_mode)
+                return
 
-        assert socket_response.payload is not None
+            await self._check_for_new_deployment_target()
 
-        deployment_target_model_id = socket_response.payload['target_model_id']
-        deployment_target_model_version = socket_response.payload['target_model_version']
+            self.status.reset_error('update_model')
+            if self.target_model is None:
+                self.log.debug('not running any updates; target model is None')
+                return
+
+            current_version = self.detector_logic.model_info.version \
+                if self.detector_logic.model_info is not None else None
+
+            if current_version != self.target_model.version:
+                self.log.info('Model is beeing updated from %s to %s',
+                              current_version or "-", self.target_model.version)
+                await self._update_model(self.target_model)
+
+        except Exception as e:
+            self.log.exception('check_for_update failed')
+            msg = e.cause if isinstance(e, DownloadError) else str(e)
+            self.status.set_error('update_model', f'Could not update model: {msg}')
+            await self._sync_status_with_loop(force=True)
+
+    async def _check_for_new_deployment_target(self) -> None:
+        """Ask the learning loop for the current deployment target and update self.loop_deployment_target.
+        If version_control is set to FollowLoop, also update target_model."""
+        try:
+            response = await self.loop_communicator.get(
+                f'/{self.organization}/projects/{self.project}/deployment/target')
+        except Exception:
+            self.log.warning('Exception while trying to check for new deployment target')
+            return
+
+        if response.status_code != 200:
+            self.log.warning('Failed to check for new deployment target: %s', str(response))
+            return
+
+        response_data = response.json()
+
+        deployment_target_uuid = response_data['model_uuid']
+        deployment_target_version = response_data['version']
         self.loop_deployment_target = ModelInformation(organization=self.organization, project=self.project,
                                                        host="", categories=[],
-                                                       id=deployment_target_model_id,
-                                                       version=deployment_target_model_version)
+                                                       id=deployment_target_uuid,
+                                                       version=deployment_target_version)
 
         if (self.version_control == VersionMode.FollowLoop and
                 self.target_model != self.loop_deployment_target):
-            old_target_model_version = self.target_model.version if self.target_model else None
+            previous_version = self.target_model.version if self.target_model else None
             self.target_model = self.loop_deployment_target
-            self.log.info('After sending status. Target_model changed from %s to %s',
-                          old_target_model_version, self.target_model.version)
+            self.log.info('Deployment target changed from %s to %s',
+                          previous_version, self.target_model.version)
+
+    async def _update_model(self, target_model: ModelInformation) -> None:
+        """Download and install the target model.
+        On failure, the target_model will be set to None which will trigger a retry on the next check."""
+
+        with step_into(GLOBALS.data_folder):
+            target_model_folder = f'models/{target_model.version}'
+            if os.path.exists(target_model_folder) and len(os.listdir(target_model_folder)) > 0:
+                self.log.info('No need to download model. %s (already exists)', target_model.version)
+            else:
+                os.makedirs(target_model_folder, exist_ok=True)
+                try:
+                    await self.data_exchanger.download_model(target_model_folder,
+                                                             Context(organization=self.organization,
+                                                                     project=self.project),
+                                                             target_model.id, self.detector_logic.model_format)
+                    self.log.info('Downloaded model %s', target_model.version)
+                except Exception:
+                    self.log.exception('Could not download model %s', target_model.version)
+                    shutil.rmtree(target_model_folder, ignore_errors=True)
+                    self.target_model = None
+                    return
+
+            model_symlink = 'model'
+            try:
+                os.unlink(model_symlink)
+                os.remove(model_symlink)
+            except Exception:
+                pass
+            os.symlink(target_model_folder, model_symlink)
+            self.log.info('Updated symlink for model to %s', os.readlink(model_symlink))
+
+            try:
+                self.detector_logic.load_model_info_and_init_model()
+            except NodeNeedsRestartError:
+                self.log.error('Node needs restart')
+                sys.exit(0)
+            except Exception:
+                self.log.exception('Could not load model, will retry download on next check')
+                shutil.rmtree(target_model_folder, ignore_errors=True)
+                self.target_model = None
+                return
+
+            await self._sync_status_with_loop(force=True)
+            # self.reload(reason='new model installed')
+
+# ================================== API Implementations ==================================
 
     async def set_operation_mode(self, mode: OperationMode):
         self.operation_mode = mode
-        try:
-            await self.sync_status_with_learning_loop()
-        except Exception as e:
-            self.log.warning('Operation mode set to %s, but sync failed: %s', mode, e)
+        await self._sync_status_with_loop(force=True)
 
     def reload(self, reason: str):
         """provide a cause for the reload"""

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -418,7 +418,7 @@ class DetectorNode(Node):
             Exception: If the communication with the Learning Loop failed.
         """
 
-        if not self._sio_client or not self._sio_client.connected:
+        if not self.sio_client or not self.sio_client.connected:
             self.log.info('Status sync failed: not connected')
             raise Exception('Status sync failed: not connected')
 
@@ -445,7 +445,7 @@ class DetectorNode(Node):
 
         # NOTE: sending organization and project is no longer required!
         try:
-            response = await self._sio_client.call('update_detector', (self.organization, self.project, jsonable_encoder(asdict(status))))
+            response = await self.sio_client.call('update_detector', (self.organization, self.project, jsonable_encoder(asdict(status))))
         except TimeoutError:
             self.socket_connection_broken = True
             self.log.exception('TimeoutError for sending status update (will try to reconnect):')

--- a/learning_loop_node/detector/outbox.py
+++ b/learning_loop_node/detector/outbox.py
@@ -189,7 +189,7 @@ class Outbox():
 
     async def _continuous_upload(self) -> None:
         self.log.info('continuous upload started')
-        assert self.shutdown_event is not None
+        assert self.shutdown_event is not None, 'shutdown_event is None'
         while not self.shutdown_event.is_set():
             await self.upload()
             await asyncio.sleep(self.UPLOAD_INTERVAL_S)
@@ -287,7 +287,7 @@ class Outbox():
             return True
 
         try:
-            assert self.shutdown_event is not None
+            assert self.shutdown_event is not None, 'shutdown_event is None'
             self.shutdown_event.set()
             await asyncio.wait_for(self.upload_task, timeout=self.UPLOAD_TIMEOUT_S + 1)
         except asyncio.TimeoutError:

--- a/learning_loop_node/node.py
+++ b/learning_loop_node/node.py
@@ -4,9 +4,9 @@ from .helpers import log_conf  # pylint: disable=unused-import
 
 # isort: split
 # pylint: disable=wrong-import-order,ungrouped-imports
-
 import asyncio
 import logging
+import os
 import ssl
 import sys
 from abc import abstractmethod
@@ -73,7 +73,7 @@ class Node(FastAPI):
 
         self.repeat_task: Any = None
         self.socket_connection_broken = False
-        self._skip_repeat_loop = False
+        self._skip_repeat_loop = os.environ.get('SKIP_REPEAT_ON_START', '0') in ('True', 'true', '1')
 
         self.include_router(router)
 

--- a/learning_loop_node/node.py
+++ b/learning_loop_node/node.py
@@ -172,7 +172,7 @@ class Node(FastAPI):
 
     async def reconnect_to_loop(self) -> None:
         """Initialize the loop communicator, log in if needed and reconnect to the loop via socket.io."""
-        if self._needs_sio:
+        if not self._needs_sio:
             return
         self.init_loop_communicator()
         await self.loop_communicator.backend_ready(timeout=5)

--- a/learning_loop_node/rest.py
+++ b/learning_loop_node/rest.py
@@ -37,7 +37,7 @@ async def _debug_logging(request: Request) -> str:
 @router.put("/socketio")
 async def _socketio(request: Request) -> str:
     '''
-    Enable or disable the socketio connection to the learning loop.
+    Enable or disable the socketio connection and repeat loop to the learning loop.
     Not intended to be used outside of testing.
 
     Example Usage
@@ -47,11 +47,9 @@ async def _socketio(request: Request) -> str:
     state = str(await request.body(), 'utf-8')
     node: 'Node' = request.app
 
-    if not node.sio_client:
-        raise HTTPException(status_code=400, detail='Node has no socketio client')
-
     if state == 'off':
-        await node.sio_client.disconnect()
+        if node.sio_client:
+            await node.sio_client.disconnect()
         node.set_skip_repeat_loop(True)  # Prevent auto-reconnection
         return 'off'
     if state == 'on':

--- a/learning_loop_node/rest.py
+++ b/learning_loop_node/rest.py
@@ -47,11 +47,11 @@ async def _socketio(request: Request) -> str:
     state = str(await request.body(), 'utf-8')
     node: 'Node' = request.app
 
-    if not node._sio_client:
+    if not node.sio_client:
         raise HTTPException(status_code=400, detail='Node has no socketio client')
 
     if state == 'off':
-        await node._sio_client.disconnect()
+        await node.sio_client.disconnect()
         node.set_skip_repeat_loop(True)  # Prevent auto-reconnection
         return 'off'
     if state == 'on':

--- a/learning_loop_node/rest.py
+++ b/learning_loop_node/rest.py
@@ -47,8 +47,11 @@ async def _socketio(request: Request) -> str:
     state = str(await request.body(), 'utf-8')
     node: 'Node' = request.app
 
+    if not node._sio_client:
+        raise HTTPException(status_code=400, detail='Node has no socketio client')
+
     if state == 'off':
-        await node.sio_client.disconnect()
+        await node._sio_client.disconnect()
         node.set_skip_repeat_loop(True)  # Prevent auto-reconnection
         return 'off'
     if state == 'on':

--- a/learning_loop_node/tests/annotator/test_annotator_node.py
+++ b/learning_loop_node/tests/annotator/test_annotator_node.py
@@ -46,12 +46,15 @@ def default_user_input() -> UserInput:
 @pytest.mark.asyncio
 @pytest.mark.usefixtures('setup_test_project')
 async def test_image_download():
+    # pylint: disable=protected-access
+
     image_folder = '/tmp/learning_loop_lib_data/zauberzeug/pytest_nodelib_annotator/images'
 
     assert os.path.exists(image_folder) is False or len(os.listdir(image_folder)) == 0
 
     node = AnnotatorNode(name="", uuid="", annotator_logic=MockedAnnotatatorLogic())
     user_input = default_user_input()
-    _ = await node._handle_user_input(jsonable_encoder(asdict(user_input)))  # pylint: disable=protected-access
+    await node._ensure_sio_connection()  # This is required as the node is not "started"
+    _ = await node._handle_user_input(jsonable_encoder(asdict(user_input)))
 
     assert os.path.exists(image_folder) is True and len(os.listdir(image_folder)) == 1

--- a/learning_loop_node/tests/detector/test_outbox.py
+++ b/learning_loop_node/tests/detector/test_outbox.py
@@ -13,6 +13,7 @@ from ...globals import GLOBALS
 
 
 @pytest.fixture()
+@pytest.mark.asyncio
 async def test_outbox():
     os.environ['LOOP_ORGANIZATION'] = 'zauberzeug'
     os.environ['LOOP_PROJECT'] = 'demo'
@@ -30,22 +31,13 @@ async def test_outbox_upload_is_successful(test_outbox: Outbox):
     await asyncio.sleep(1)
     await test_outbox.save(get_test_image_binary())
     assert await wait_for_outbox_count(test_outbox, 2)
-    await test_outbox.set_mode('continuous_upload')
-    await asyncio.sleep(6)
-    # await asyncio.sleep(1)
-    # await test_outbox.upload()
+    await test_outbox.upload()
     assert await wait_for_outbox_count(test_outbox, 0)
     assert test_outbox.upload_counter == 2
 
-    await test_outbox.set_mode('stopped')
+    # 2nd upload fails on CI
     await test_outbox.save(get_test_image_binary())
-    assert await wait_for_outbox_count(test_outbox, 1)
-    await asyncio.sleep(6)
-    assert await wait_for_outbox_count(test_outbox, 1), 'File was cleared even though outbox should be stopped'
-
-    await test_outbox.set_mode('continuous_upload')
-    assert await wait_for_outbox_count(test_outbox, 0, timeout=15), 'File was not cleared even though outbox should be in continuous_upload'
-    assert test_outbox.upload_counter == 3
+    await test_outbox.upload()
 
 
 @pytest.mark.asyncio

--- a/learning_loop_node/tests/detector/test_outbox.py
+++ b/learning_loop_node/tests/detector/test_outbox.py
@@ -43,6 +43,7 @@ async def test_outbox_upload_is_successful(test_outbox: Outbox):
     await asyncio.sleep(1)
     await test_outbox.save(get_test_image_binary())
     assert await wait_for_outbox_count(test_outbox, 2)
+    await asyncio.sleep(1)
     await test_outbox.upload()
     assert await wait_for_outbox_count(test_outbox, 0)
     assert test_outbox.upload_counter == 2

--- a/learning_loop_node/tests/detector/test_outbox.py
+++ b/learning_loop_node/tests/detector/test_outbox.py
@@ -43,7 +43,7 @@ async def test_set_outbox_mode(test_outbox: Outbox):
     assert await wait_for_outbox_count(test_outbox, 2)
     await test_outbox.set_mode('continuous_upload')
     # await test_outbox.upload()
-    assert await wait_for_outbox_count(test_outbox, 0)
+    assert await wait_for_outbox_count(test_outbox, 0, timeout=90)
     assert test_outbox.upload_counter == 3
 
 

--- a/learning_loop_node/tests/detector/test_outbox.py
+++ b/learning_loop_node/tests/detector/test_outbox.py
@@ -39,14 +39,10 @@ async def test_set_outbox_mode(test_outbox: Outbox):
     await test_outbox.save(get_test_image_binary())
     await asyncio.sleep(1)
     await test_outbox.save(get_test_image_binary())
-    assert await wait_for_outbox_count(test_outbox, 2)
+    assert await wait_for_outbox_count(test_outbox, 3)
     await test_outbox.upload()
     assert await wait_for_outbox_count(test_outbox, 0)
-    assert test_outbox.upload_counter == 2
-
-    # 2nd upload fails on CI
-    await test_outbox.save(get_test_image_binary())
-    await test_outbox.upload()
+    assert test_outbox.upload_counter == 3
 
 
 @pytest.mark.asyncio

--- a/learning_loop_node/tests/detector/test_outbox.py
+++ b/learning_loop_node/tests/detector/test_outbox.py
@@ -36,11 +36,13 @@ async def test_set_outbox_mode(test_outbox: Outbox):
     assert await wait_for_outbox_count(test_outbox, 0, timeout=15), 'File was not cleared even though outbox should be in continuous_upload'
     assert test_outbox.upload_counter == 1
 
+    await test_outbox.set_mode('stopped')
+    await test_outbox.save(get_test_image_binary())
     await test_outbox.save(get_test_image_binary())
     await asyncio.sleep(1)
-    await test_outbox.save(get_test_image_binary())
-    assert await wait_for_outbox_count(test_outbox, 3)
-    await test_outbox.upload()
+    assert await wait_for_outbox_count(test_outbox, 2)
+    await test_outbox.set_mode('continuous_upload')
+    # await test_outbox.upload()
     assert await wait_for_outbox_count(test_outbox, 0)
     assert test_outbox.upload_counter == 3
 

--- a/learning_loop_node/tests/detector/test_outbox.py
+++ b/learning_loop_node/tests/detector/test_outbox.py
@@ -43,8 +43,10 @@ async def test_outbox_upload_is_successful(test_outbox: Outbox):
     await asyncio.sleep(1)
     await test_outbox.save(get_test_image_binary())
     assert await wait_for_outbox_count(test_outbox, 2)
-    await asyncio.sleep(1)
-    await test_outbox.upload()
+    await test_outbox.set_mode('continuous_upload')
+    await asyncio.sleep(6)
+    # await asyncio.sleep(1)
+    # await test_outbox.upload()
     assert await wait_for_outbox_count(test_outbox, 0)
     assert test_outbox.upload_counter == 2
 
@@ -59,14 +61,13 @@ async def test_invalid_jpg_is_not_saved(test_outbox: Outbox):
 # ------------------------------ Helper functions --------------------------------------
 
 
-def get_test_image_binary():
-    img = Image.new('RGB', (60, 30), color=(73, 109, 137))
+def get_test_image_binary() -> bytes:
+    img = Image.new('RGB', (600, 300), color=(73, 109, 137))
     # convert img to jpg binary
 
     img_byte_arr = io.BytesIO()
     img.save(img_byte_arr, format='JPEG')
-    img_byte_arr = img_byte_arr.getvalue()
-    return img_byte_arr
+    return img_byte_arr.getvalue()
 
     # return img.tobytes() # NOT WORKING
 

--- a/learning_loop_node/tests/detector/test_outbox.py
+++ b/learning_loop_node/tests/detector/test_outbox.py
@@ -37,6 +37,16 @@ async def test_outbox_upload_is_successful(test_outbox: Outbox):
     assert await wait_for_outbox_count(test_outbox, 0)
     assert test_outbox.upload_counter == 2
 
+    await test_outbox.set_mode('stopped')
+    await test_outbox.save(get_test_image_binary())
+    assert await wait_for_outbox_count(test_outbox, 1)
+    await asyncio.sleep(6)
+    assert await wait_for_outbox_count(test_outbox, 1), 'File was cleared even though outbox should be stopped'
+
+    await test_outbox.set_mode('continuous_upload')
+    assert await wait_for_outbox_count(test_outbox, 0, timeout=15), 'File was not cleared even though outbox should be in continuous_upload'
+    assert test_outbox.upload_counter == 3
+
 
 @pytest.mark.asyncio
 async def test_set_outbox_mode(test_outbox: Outbox):

--- a/learning_loop_node/tests/detector/test_outbox.py
+++ b/learning_loop_node/tests/detector/test_outbox.py
@@ -25,19 +25,6 @@ async def test_outbox():
 
 
 @pytest.mark.asyncio
-async def test_set_outbox_mode(test_outbox: Outbox):
-    await test_outbox.set_mode('stopped')
-    await test_outbox.save(get_test_image_binary())
-    assert await wait_for_outbox_count(test_outbox, 1)
-    await asyncio.sleep(6)
-    assert await wait_for_outbox_count(test_outbox, 1), 'File was cleared even though outbox should be stopped'
-
-    await test_outbox.set_mode('continuous_upload')
-    assert await wait_for_outbox_count(test_outbox, 0, timeout=15), 'File was not cleared even though outbox should be in continuous_upload'
-    assert test_outbox.upload_counter == 1
-
-
-@pytest.mark.asyncio
 async def test_outbox_upload_is_successful(test_outbox: Outbox):
     await test_outbox.save(get_test_image_binary())
     await asyncio.sleep(1)
@@ -49,6 +36,19 @@ async def test_outbox_upload_is_successful(test_outbox: Outbox):
     # await test_outbox.upload()
     assert await wait_for_outbox_count(test_outbox, 0)
     assert test_outbox.upload_counter == 2
+
+
+@pytest.mark.asyncio
+async def test_set_outbox_mode(test_outbox: Outbox):
+    await test_outbox.set_mode('stopped')
+    await test_outbox.save(get_test_image_binary())
+    assert await wait_for_outbox_count(test_outbox, 1)
+    await asyncio.sleep(6)
+    assert await wait_for_outbox_count(test_outbox, 1), 'File was cleared even though outbox should be stopped'
+
+    await test_outbox.set_mode('continuous_upload')
+    assert await wait_for_outbox_count(test_outbox, 0, timeout=15), 'File was not cleared even though outbox should be in continuous_upload'
+    assert test_outbox.upload_counter == 1
 
 
 @pytest.mark.asyncio

--- a/learning_loop_node/tests/trainer/states/test_state_sync_confusion_matrix.py
+++ b/learning_loop_node/tests/trainer/states/test_state_sync_confusion_matrix.py
@@ -54,13 +54,13 @@ async def test_unsynced_model_available__sync_successful(test_initialized_traine
 async def test_unsynced_model_available__sio_not_connected(test_initialized_trainer_node: TrainerNode):
     trainer = test_initialized_trainer_node.trainer_logic
     assert isinstance(trainer, TestingTrainerLogic)
-    assert test_initialized_trainer_node._sio_client is not None
+    assert test_initialized_trainer_node.sio_client is not None
 
-    await test_initialized_trainer_node._sio_client.disconnect()
+    await test_initialized_trainer_node.sio_client.disconnect()
     test_initialized_trainer_node.set_skip_repeat_loop(True)
     create_active_training_file(trainer, training_state=TrainerState.TrainingFinished)
 
-    assert test_initialized_trainer_node._sio_client.connected is False
+    assert test_initialized_trainer_node.sio_client.connected is False
     trainer.has_new_model = True
 
     trainer._begin_training_task()
@@ -97,8 +97,8 @@ async def test_basic_mock(test_initialized_trainer_node: TrainerNode, mocker: Mo
 
     patched_call_return_value: asyncio.Future = asyncio.Future()
     patched_call_return_value.set_result({'success': True})
-    mocker.patch.object(node._sio_client, 'call', return_value=patched_call_return_value)
-    assert await (await node._sio_client.call()) == {'success': True}  # type: ignore
+    mocker.patch.object(node.sio_client, 'call', return_value=patched_call_return_value)
+    assert await (await node.sio_client.call()) == {'success': True}  # type: ignore
 
 
 async def mock_socket_io_call(mocker, trainer_node: TrainerNode, return_value):
@@ -106,10 +106,10 @@ async def mock_socket_io_call(mocker, trainer_node: TrainerNode, return_value):
     Patch the socketio call function to always return the given return_value
     '''
     for _ in range(10):
-        if trainer_node._sio_client is None:
+        if trainer_node.sio_client is None:
             await asyncio.sleep(0.1)
         else:
             break
     else:
-        raise Exception('sio_client is not available ' + str(trainer_node._sio_client))
-    mocker.patch.object(trainer_node._sio_client, 'call', return_value=return_value)
+        raise Exception('sio_client is not available ' + str(trainer_node.sio_client))
+    mocker.patch.object(trainer_node.sio_client, 'call', return_value=return_value)

--- a/learning_loop_node/tests/trainer/states/test_state_sync_confusion_matrix.py
+++ b/learning_loop_node/tests/trainer/states/test_state_sync_confusion_matrix.py
@@ -54,12 +54,13 @@ async def test_unsynced_model_available__sync_successful(test_initialized_traine
 async def test_unsynced_model_available__sio_not_connected(test_initialized_trainer_node: TrainerNode):
     trainer = test_initialized_trainer_node.trainer_logic
     assert isinstance(trainer, TestingTrainerLogic)
+    assert test_initialized_trainer_node._sio_client is not None
 
-    await test_initialized_trainer_node.sio_client.disconnect()
+    await test_initialized_trainer_node._sio_client.disconnect()
     test_initialized_trainer_node.set_skip_repeat_loop(True)
     create_active_training_file(trainer, training_state=TrainerState.TrainingFinished)
 
-    assert test_initialized_trainer_node.sio_client.connected is False
+    assert test_initialized_trainer_node._sio_client.connected is False
     trainer.has_new_model = True
 
     trainer._begin_training_task()
@@ -96,8 +97,8 @@ async def test_basic_mock(test_initialized_trainer_node: TrainerNode, mocker: Mo
 
     patched_call_return_value: asyncio.Future = asyncio.Future()
     patched_call_return_value.set_result({'success': True})
-    mocker.patch.object(node.sio_client, 'call', return_value=patched_call_return_value)
-    assert await (await node.sio_client.call()) == {'success': True}  # type: ignore
+    mocker.patch.object(node._sio_client, 'call', return_value=patched_call_return_value)
+    assert await (await node._sio_client.call()) == {'success': True}  # type: ignore
 
 
 async def mock_socket_io_call(mocker, trainer_node: TrainerNode, return_value):
@@ -105,10 +106,10 @@ async def mock_socket_io_call(mocker, trainer_node: TrainerNode, return_value):
     Patch the socketio call function to always return the given return_value
     '''
     for _ in range(10):
-        if trainer_node.sio_client is None:
+        if trainer_node._sio_client is None:
             await asyncio.sleep(0.1)
         else:
             break
     else:
-        raise Exception('sio_client is not available ' + str(trainer_node.sio_client))
-    mocker.patch.object(trainer_node.sio_client, 'call', return_value=return_value)
+        raise Exception('sio_client is not available ' + str(trainer_node._sio_client))
+    mocker.patch.object(trainer_node._sio_client, 'call', return_value=return_value)

--- a/learning_loop_node/tests/trainer/states/test_state_sync_confusion_matrix.py
+++ b/learning_loop_node/tests/trainer/states/test_state_sync_confusion_matrix.py
@@ -1,7 +1,9 @@
 
 import asyncio
 
-from pytest_mock import MockerFixture  # pip install pytest-mock
+from pytest_mock import (  # pip install pytest-mock # pylint: disable=import-error # type: ignore
+    MockerFixture,
+)
 
 from ....enums import TrainerState
 from ....trainer.trainer_logic import TrainerLogic

--- a/learning_loop_node/trainer/trainer_logic_generic.py
+++ b/learning_loop_node/trainer/trainer_logic_generic.py
@@ -369,7 +369,7 @@ class TrainerLogicGeneric(ABC):
         """Syncronizes the training with the Learning Loop via the update_training endpoint.
         NOTE: This stage sets the errors explicitly because it may be used inside the training stage.
         """
-        if not self.node._sio_client or not self.node._sio_client.connected:
+        if not self.node.sio_client or not self.node.sio_client.connected:
             raise ConnectionError('SocketIO client is not connected')
 
         error_key = 'sync_confusion_matrix'
@@ -385,7 +385,7 @@ class TrainerLogicGeneric(ABC):
                                            best_epoch=new_best_model.epoch)
                 await asyncio.sleep(0.1)  # NOTE needed for tests.
 
-                result = await self.node._sio_client.call('update_training', (
+                result = await self.node.sio_client.call('update_training', (
                     self.training.context.organization, self.training.context.project, jsonable_encoder(new_training)))
                 if isinstance(result,  dict) and result['success']:
                     logger.info('successfully updated training %s', asdict(new_training))

--- a/learning_loop_node/trainer/trainer_logic_generic.py
+++ b/learning_loop_node/trainer/trainer_logic_generic.py
@@ -369,6 +369,9 @@ class TrainerLogicGeneric(ABC):
         """Syncronizes the training with the Learning Loop via the update_training endpoint.
         NOTE: This stage sets the errors explicitly because it may be used inside the training stage.
         """
+        if not self.node._sio_client or not self.node._sio_client.connected:
+            raise ConnectionError('SocketIO client is not connected')
+
         error_key = 'sync_confusion_matrix'
         try:
             new_best_model = self._get_new_best_training_state()
@@ -382,7 +385,7 @@ class TrainerLogicGeneric(ABC):
                                            best_epoch=new_best_model.epoch)
                 await asyncio.sleep(0.1)  # NOTE needed for tests.
 
-                result = await self.node.sio_client.call('update_training', (
+                result = await self.node._sio_client.call('update_training', (
                     self.training.context.organization, self.training.context.project, jsonable_encoder(new_training)))
                 if isinstance(result,  dict) and result['success']:
                     logger.info('successfully updated training %s', asdict(new_training))

--- a/learning_loop_node/trainer/trainer_node.py
+++ b/learning_loop_node/trainer/trainer_node.py
@@ -16,7 +16,7 @@ from .trainer_logic_generic import TrainerLogicGeneric
 class TrainerNode(Node):
 
     def __init__(self, name: str, trainer_logic: TrainerLogicGeneric, uuid: Optional[str] = None, use_backdoor_controls: bool = False):
-        super().__init__(name, uuid, 'trainer')
+        super().__init__(name, uuid=uuid, node_type='trainer')
         trainer_logic._node = self
         self.trainer_logic = trainer_logic
         self.last_training_io = LastTrainingIO(self.uuid)

--- a/learning_loop_node/trainer/trainer_node.py
+++ b/learning_loop_node/trainer/trainer_node.py
@@ -52,8 +52,8 @@ class TrainerNode(Node):
             self.check_idle_timeout()
         except exceptions.TimeoutError:
             self.log.warning('timeout when sending status to learning loop, reconnecting sio_client')
-            if self._sio_client:
-                await self._sio_client.disconnect()  # NOTE: reconnect happens in node._on_repeat
+            if self.sio_client:
+                await self.sio_client.disconnect()  # NOTE: reconnect happens in node._on_repeat
         except Exception:
             self.log.exception('could not send status. Exception:')
 
@@ -77,14 +77,14 @@ class TrainerNode(Node):
             return True
 
     async def send_status(self):
-        if not self._sio_client or not self._sio_client.connected:
+        if not self.sio_client or not self.sio_client.connected:
             self.log.debug('cannot send status - not connected to the Learning Loop')
             return
 
         status = self.trainer_logic.generate_status_for_loop(self.uuid, self.name)
         self.log_status_on_change(status.state or 'None', status.short_str())
 
-        result = await self._sio_client.call('update_trainer', jsonable_encoder(asdict(status)), timeout=30)
+        result = await self.sio_client.call('update_trainer', jsonable_encoder(asdict(status)), timeout=30)
         if isinstance(result, Dict) and not result['success']:
             self.socket_connection_broken = True
             self.log.error('Error when sending status update: Response from loop was:\n %s', result)


### PR DESCRIPTION
# Motivation

The SocketIO connection between detector and learning loop was unstable, often resulting in frequent reconnects and a huge work load at the backend. At the same time a SIO connection is not required so we decided to replace all communication with REST calls.

# Implementation

Split status update and check for new deployment target.
Sync status only every N repeat cycles (overwritten at test time)
