### PR TITLE
Detector API Workover

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Images can be send to the detector node via socketio or rest.
 Via **REST** you may provide the following parameters:
 
 - `autoupload`: configures auto-submission to the learning loop; `filtered` (default), `all`, `disabled`
-- `camera-id`: a camera identifier (string) used to improve the autoupload filtering
+- `camera_id`: a camera identifier (string) used to improve the autoupload filtering
 - `tags`: comma separated list of tags to add to the image in the learning loop
 - `source`: optional source identifier (str) for the image (e.g. a robot id)
 - `autoupload`: configures auto-submission to the learning loop; `filtered` (default), `all`, `disabled`
@@ -59,7 +59,7 @@ Via **REST** you may provide the following parameters:
 
 Example usage:
 
-`curl --request POST -F 'file=@test.jpg' -H 'autoupload: all' -H 'camera-id: front_cam' localhost:8004/detect`
+`curl --request POST -F 'file=@test.jpg' -H 'autoupload: all' -H 'camera_id: front_cam' localhost:8004/detect`
 
 To use the **SocketIO** inference EPs, the caller needs to connect to the detector node's SocketIO server and emit the `detect` or `batch_detect` event with the image data and image metadata.
 Example code can be found [in the rosys implementation](https://github.com/zauberzeug/rosys/blob/main/rosys/vision/detector_hardware.py).

--- a/README.md
+++ b/README.md
@@ -45,33 +45,47 @@ from learning_loop_node/learning_loop_node
 
 Detector Nodes are normally deployed on edge devices like robots or machinery but can also run in the cloud to provide backend services for an app or similar. These nodes register themself at the Learning Loop. They provide REST and Socket.io APIs to run inference on images. The processed images can automatically be used for active learning: e.g. uncertain predictions will be send to the Learning Loop.
 
-### Running Inference
+### Inference API
 
 Images can be send to the detector node via socketio or rest.
-The later approach can be used via curl,
+Via **REST** you may provide the following parameters:
+
+- `autoupload`: configures auto-submission to the learning loop; `filtered` (default), `all`, `disabled`
+- `camera-id`: a camera identifier (string) used to improve the autoupload filtering
+- `tags`: comma separated list of tags to add to the image in the learning loop
+- `source`: optional source identifier (str) for the image (e.g. a robot id)
+- `autoupload`: configures auto-submission to the learning loop; `filtered` (default), `all`, `disabled`
+- `creation_date`: optional creation date (str) for the image in isoformat (e.g. `2023-01-30T12:34:56`)
 
 Example usage:
 
-`curl --request POST -F 'file=@test.jpg' localhost:8004/detect`
+`curl --request POST -F 'file=@test.jpg'  -H 'autoupload: all' -H 'camera-id: front_cam' localhost:8004/detect`
 
-Where 8804 is the specified port in this example.
-You can additionally provide the following camera parameters:
+To use the **SocketIO** inference EPs, the caller needs to connect to the detector node's SocketIO server and emit the `detect` or `batch_detect` event with the image data and image metadata.
+Example code can be found [in the rosys implementation](https://github.com/zauberzeug/rosys/blob/main/rosys/vision/detector_hardware.py).
 
-- `autoupload`: configures auto-submission to the learning loop; `filtered` (default), `all`, `disabled` (example curl parameter `-H 'autoupload: all'`)
-- `camera-id`: a string which groups images for submission together (example curl parameter `-H 'camera-id: front_cam'`)
+### Upload API
 
-To use the socketio interface, the caller needs to connect to the detector node's socketio server and emit the `detect` or `batch_detect` event with the image data and image metadata. Example code can be found [in the rosys implementation](https://github.com/zauberzeug/rosys/blob/main/rosys/vision/detector_hardware.py).
+The detector has a **REST** endpoint to upload images (and detections) to the Learning Loop. The endpoint takes a POST request with one or multiple images. The images are expected to be in jpg format. The following optional parameters may be set via headers:
 
-The detector also has a sio **upload endpoint** that can be used to upload images and detections to the learning loop. The function receives a json dictionary, with the following entries:
+- `source`: optional source identifier (str) for the image (e.g. a robot id)
+- `creation_date`: optional creation date (str) for the image in isoformat (e.g. `2023-01-30T12:34:56`)
+- `upload_priority`: A boolean flag to prioritize the upload (defaults to False)
+
+Example:
+
+`curl -X POST -F 'files=@test.jpg' "http://localhost:/upload"`
+
+The detector also has a **SocketIO** upload endpoint that can be used to upload images and detections to the learning loop. The function receives a json dictionary, with the following entries:
 
 - `image`: the image data in jpg format
-- `tags`: a list of strings. If not provided the tag is `picked_by_system`
-- `detections`: a dictionary representing the detections. UUIDs for the classes are automatically determined based on the category names. This field is optional. If not provided, no detections are uploaded.
-- `source`: optional source identifier for the image
-- `creation_date`: optional creation date for the image
+
+- `metadata`: a dictionary representing the image metadata. If metadata contains detections and/or annotations, UUIDs for the classes are automatically determined based on the category names. Metadata should follow the schema of the `ImageMetadata` data class.
 - `upload_priority`: boolean flag to prioritize the upload (defaults to False)
 
 The endpoint returns None if the upload was successful and an error message otherwise.
+
+For both ways to upload an image, the tag `picked_by_system` is automatically added to the image metadata.
 
 ### Changing the model versioning mode
 
@@ -123,12 +137,6 @@ The outbox mode can also be queried via:
 
 - HTTP: `curl http://localhost/outbox_mode`
 - SocketIO: `sio.emit('get_outbox_mode')`
-
-### Explicit upload
-
-The detector has a REST endpoint to upload images (and detections) to the Learning Loop. The endpoint takes a POST request with the image and optionally the detections. The image is expected to be in jpg format. The detections are expected to be a json dictionary. Example:
-
-`curl -X POST -F 'files=@test.jpg' "http://localhost:/upload"`
 
 ## Trainer Node
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Via **REST** you may provide the following parameters:
 
 Example usage:
 
-`curl --request POST -F 'file=@test.jpg'  -H 'autoupload: all' -H 'camera-id: front_cam' localhost:8004/detect`
+`curl --request POST -F 'file=@test.jpg' -H 'autoupload: all' -H 'camera-id: front_cam' localhost:8004/detect`
 
 To use the **SocketIO** inference EPs, the caller needs to connect to the detector node's SocketIO server and emit the `detect` or `batch_detect` event with the image data and image metadata.
 Example code can be found [in the rosys implementation](https://github.com/zauberzeug/rosys/blob/main/rosys/vision/detector_hardware.py).
@@ -152,7 +152,7 @@ A Conveter Node converts models from one format into another.
 
 ...
 
-#### Test operability
+### Test operability
 
 Assumend there is a Converter Node which converts models of format 'format_a' into 'format_b'.
 Upload a model with

--- a/learning_loop_node/data_classes/__init__.py
+++ b/learning_loop_node/data_classes/__init__.py
@@ -1,4 +1,9 @@
-from .annotations import AnnotationData, SegmentationAnnotation, ToolOutput, UserInput
+from .annotation_data import (
+    AnnotationData,
+    SegmentationAnnotation,
+    ToolOutput,
+    UserInput,
+)
 from .detections import (
     BoxDetection,
     ClassificationDetection,

--- a/learning_loop_node/data_classes/annotation_data.py
+++ b/learning_loop_node/data_classes/annotation_data.py
@@ -1,0 +1,43 @@
+import sys
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from ..enums import AnnotationEventType
+from .detections import Point, Shape
+from .general import Category, Context
+
+KWONLY_SLOTS = {'kw_only': True, 'slots': True} if sys.version_info >= (3, 10) else {}
+
+
+@dataclass(**KWONLY_SLOTS)
+class AnnotationData():
+    coordinate: Point
+    event_type: Union[AnnotationEventType, str]
+    context: Context
+    image_uuid: str
+    category: Category
+
+    key_up: Optional[str] = None
+    key_down: Optional[str] = None
+    epsilon: Optional[float] = None
+    is_shift_key_pressed: Optional[bool] = None
+
+
+@dataclass(**KWONLY_SLOTS)
+class SegmentationAnnotation():
+    id: str
+    shape: Shape
+    image_id: str
+    category_id: str
+
+
+@dataclass(**KWONLY_SLOTS)
+class UserInput():
+    frontend_id: str
+    data: AnnotationData
+
+
+@dataclass(**KWONLY_SLOTS)
+class ToolOutput():
+    svg: str
+    annotation: Optional[SegmentationAnnotation] = None

--- a/learning_loop_node/data_classes/annotations.py
+++ b/learning_loop_node/data_classes/annotations.py
@@ -1,43 +1,50 @@
-import sys
-from dataclasses import dataclass
-from typing import Optional, Union
 
-from ..enums import AnnotationEventType
-from .detections import Point, Shape
-from .general import Category, Context
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
 
 KWONLY_SLOTS = {'kw_only': True, 'slots': True} if sys.version_info >= (3, 10) else {}
 
 
 @dataclass(**KWONLY_SLOTS)
-class AnnotationData():
-    coordinate: Point
-    event_type: Union[AnnotationEventType, str]
-    context: Context
-    image_uuid: str
-    category: Category
+class BoxAnnotation():
+    """Coordinates according to COCO format. x,y is the top left corner of the box.
+    x increases to the right, y increases downwards.
+    """
+    category_name: str = field(metadata={'description': 'Category name'})
+    x: int = field(metadata={'description': 'X coordinate (left to right)'})
+    y: int = field(metadata={'description': 'Y coordinate (top to bottom)'})
+    width: int = field(metadata={'description': 'Width'})
+    height: int = field(metadata={'description': 'Height'})
+    model_name: str = field(metadata={'description': 'Model name'})
+    confidence: float = field(metadata={'description': 'Confidence'})
+    category_id: Optional[str] = field(default=None, metadata={'description': 'Category UUID'})
 
-    key_up: Optional[str] = None
-    key_down: Optional[str] = None
-    epsilon: Optional[float] = None
-    is_shift_key_pressed: Optional[bool] = None
-
-
-@dataclass(**KWONLY_SLOTS)
-class SegmentationAnnotation():
-    id: str
-    shape: Shape
-    image_id: str
-    category_id: str
+    def __str__(self):
+        return f'x:{int(self.x)} y: {int(self.y)}, w: {int(self.width)} h: {int(self.height)} c: {self.confidence:.2f} -> {self.category_name}'
 
 
 @dataclass(**KWONLY_SLOTS)
-class UserInput():
-    frontend_id: str
-    data: AnnotationData
+class PointAnnotation():
+    """Coordinates according to COCO format. x,y is the center of the point.
+    x increases to the right, y increases downwards."""
+    category_name: str = field(metadata={'description': 'Category name'})
+    x: float = field(metadata={'description': 'X coordinate (right)'})
+    y: float = field(metadata={'description': 'Y coordinate (down)'})
+    model_name: str = field(metadata={'description': 'Model name'})
+    confidence: float = field(metadata={'description': 'Confidence'})
+    category_id: Optional[str] = field(default=None, metadata={'description': 'Category UUID'})
+
+    def __str__(self):
+        return f'x:{int(self.x)} y: {int(self.y)}, c: {self.confidence:.2f} -> {self.category_name}'
 
 
 @dataclass(**KWONLY_SLOTS)
-class ToolOutput():
-    svg: str
-    annotation: Optional[SegmentationAnnotation] = None
+class ClassificationAnnotation():
+    category_name: str = field(metadata={'description': 'Category name'})
+    model_name: str = field(metadata={'description': 'Model name'})
+    confidence: float = field(metadata={'description': 'Confidence'})
+    category_id: Optional[str] = field(default=None, metadata={'description': 'Category UUID'})
+
+    def __str__(self):
+        return f'c: {self.confidence:.2f} -> {self.category_name}'

--- a/learning_loop_node/data_classes/annotations.py
+++ b/learning_loop_node/data_classes/annotations.py
@@ -16,12 +16,10 @@ class BoxAnnotation():
     y: int = field(metadata={'description': 'Y coordinate (top to bottom)'})
     width: int = field(metadata={'description': 'Width'})
     height: int = field(metadata={'description': 'Height'})
-    model_name: str = field(metadata={'description': 'Model name'})
-    confidence: float = field(metadata={'description': 'Confidence'})
     category_id: Optional[str] = field(default=None, metadata={'description': 'Category UUID'})
 
     def __str__(self):
-        return f'x:{int(self.x)} y: {int(self.y)}, w: {int(self.width)} h: {int(self.height)} c: {self.confidence:.2f} -> {self.category_name}'
+        return f'x:{int(self.x)} y: {int(self.y)}, w: {int(self.width)} h: {int(self.height)} -> {self.category_name}'
 
 
 @dataclass(**KWONLY_SLOTS)
@@ -31,20 +29,16 @@ class PointAnnotation():
     category_name: str = field(metadata={'description': 'Category name'})
     x: float = field(metadata={'description': 'X coordinate (right)'})
     y: float = field(metadata={'description': 'Y coordinate (down)'})
-    model_name: str = field(metadata={'description': 'Model name'})
-    confidence: float = field(metadata={'description': 'Confidence'})
     category_id: Optional[str] = field(default=None, metadata={'description': 'Category UUID'})
 
     def __str__(self):
-        return f'x:{int(self.x)} y: {int(self.y)}, c: {self.confidence:.2f} -> {self.category_name}'
+        return f'x:{int(self.x)} y: {int(self.y)}, -> {self.category_name}'
 
 
 @dataclass(**KWONLY_SLOTS)
 class ClassificationAnnotation():
     category_name: str = field(metadata={'description': 'Category name'})
-    model_name: str = field(metadata={'description': 'Model name'})
-    confidence: float = field(metadata={'description': 'Confidence'})
     category_id: Optional[str] = field(default=None, metadata={'description': 'Category UUID'})
 
     def __str__(self):
-        return f'c: {self.confidence:.2f} -> {self.category_name}'
+        return f'-> {self.category_name}'

--- a/learning_loop_node/data_classes/detections.py
+++ b/learning_loop_node/data_classes/detections.py
@@ -9,10 +9,6 @@ import numpy as np
 KWONLY_SLOTS = {'kw_only': True, 'slots': True} if sys.version_info >= (3, 10) else {}
 
 
-def current_datetime():
-    return datetime.now().isoformat(sep='_', timespec='milliseconds')
-
-
 @dataclass(**KWONLY_SLOTS)
 class BoxDetection():
     """Coordinates according to COCO format. x,y is the top left corner of the box.
@@ -25,7 +21,7 @@ class BoxDetection():
     height: int = field(metadata={'description': 'Height'})
     model_name: str = field(metadata={'description': 'Model name'})
     confidence: float = field(metadata={'description': 'Confidence'})
-    category_id: Optional[str] = field(default=None, metadata={'description': 'Category ID'})
+    category_id: Optional[str] = field(default=None, metadata={'description': 'Category UUID'})
 
     def intersection_over_union(self, other_detection: 'BoxDetection') -> float:
         # https://www.pyimagesearch.com/2016/11/07/intersection-over-union-iou-for-object-detection/
@@ -59,7 +55,7 @@ class PointDetection():
     y: float = field(metadata={'description': 'Y coordinate (down)'})
     model_name: str = field(metadata={'description': 'Model name'})
     confidence: float = field(metadata={'description': 'Confidence'})
-    category_id: Optional[str] = field(default=None, metadata={'description': 'Category ID'})
+    category_id: Optional[str] = field(default=None, metadata={'description': 'Category UUID'})
 
     def distance(self, other: 'PointDetection') -> float:
         return np.sqrt((other.x - self.x)**2 + (other.y - self.y)**2)
@@ -73,7 +69,7 @@ class ClassificationDetection():
     category_name: str = field(metadata={'description': 'Category name'})
     model_name: str = field(metadata={'description': 'Model name'})
     confidence: float = field(metadata={'description': 'Confidence'})
-    category_id: Optional[str] = field(default=None, metadata={'description': 'Category ID'})
+    category_id: Optional[str] = field(default=None, metadata={'description': 'Category UUID'})
 
     def __str__(self):
         return f'c: {self.confidence:.2f} -> {self.category_name}'

--- a/learning_loop_node/data_classes/image_metadata.py
+++ b/learning_loop_node/data_classes/image_metadata.py
@@ -4,7 +4,13 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import List, Optional
 
-from .detections import BoxDetection, ClassificationDetection, PointDetection, SegmentationDetection
+from .annotations import BoxAnnotation, ClassificationAnnotation, PointAnnotation
+from .detections import (
+    BoxDetection,
+    ClassificationDetection,
+    PointDetection,
+    SegmentationDetection,
+)
 
 # pylint: disable=too-many-instance-attributes
 
@@ -25,6 +31,14 @@ class ImageMetadata():
         'description': 'List of segmentation detections'})
     classification_detections: List[ClassificationDetection] = field(default_factory=list, metadata={
         'description': 'List of classification detections'})
+
+    box_annotations: List[BoxAnnotation] = field(default_factory=list, metadata={
+        'description': 'List of box annotations'})
+    point_annotations: List[PointAnnotation] = field(default_factory=list, metadata={
+        'description': 'List of point annotations'})
+    classification_annotation: Optional[ClassificationAnnotation] = field(default=None, metadata={
+        'description': 'Classification annotation'})
+
     tags: List[str] = field(default_factory=list, metadata={
         'description': 'List of tags'})
 

--- a/learning_loop_node/detector/detector_logic.py
+++ b/learning_loop_node/detector/detector_logic.py
@@ -42,18 +42,25 @@ class DetectorLogic():
     def init(self):
         """Called when a (new) model was loaded. Initialize the model. Model information available via `self.model_info`"""
 
-    def evaluate_with_all_info(self, image: bytes, tags: List[str], source: Optional[str] = None, creation_date: Optional[str] = None) -> ImageMetadata:  # pylint: disable=unused-argument
-        """Called by the detector node when an image should be evaluated (REST or SocketIO).
-        Tags, source come from the caller and may be used in this function. 
-        By default, this function simply calls `evaluate`"""
-        return self.evaluate(image)
-
     @abstractmethod
-    def evaluate(self, image: bytes) -> ImageMetadata:
+    def evaluate(self,
+                 image: bytes,
+                 tags: List[str],
+                 source: Optional[str] = None,
+                 creation_date: Optional[str] = None) -> ImageMetadata:  # pylint: disable=unused-argument
         """Evaluate the image and return the detections.
+
+        Called by the detector node when an image should be evaluated (REST or SocketIO).
+        Tags, source come from the caller and may be used in this function. 
+        Also these attributes may be transfered to ImageMetadata.
+        The resulting detections should also be stored in the ImageMetadata.
         The object should return empty detections if it is not initialized"""
 
     @abstractmethod
-    def batch_evaluate(self, images: List[bytes]) -> ImagesMetadata:
+    def batch_evaluate(self,
+                       images: List[bytes],
+                       tags: List[str],
+                       source: Optional[str] = None,
+                       creation_date: Optional[str] = None) -> ImagesMetadata:
         """Evaluate a batch of images and return the detections.
         The object should return empty detections if it is not initialized"""

--- a/learning_loop_node/detector/detector_logic.py
+++ b/learning_loop_node/detector/detector_logic.py
@@ -43,24 +43,17 @@ class DetectorLogic():
         """Called when a (new) model was loaded. Initialize the model. Model information available via `self.model_info`"""
 
     @abstractmethod
-    def evaluate(self,
-                 image: bytes,
-                 tags: List[str],
-                 source: Optional[str] = None,
-                 creation_date: Optional[str] = None) -> ImageMetadata:  # pylint: disable=unused-argument
+    def evaluate(self, image: bytes) -> ImageMetadata:  # pylint: disable=unused-argument
         """Evaluate the image and return the detections.
 
         Called by the detector node when an image should be evaluated (REST or SocketIO).
-        Tags, source come from the caller and may be used in this function. 
-        Also these attributes may be transfered to ImageMetadata.
-        The resulting detections should also be stored in the ImageMetadata.
-        The object should return empty detections if it is not initialized"""
+        The resulting detections should be stored in the ImageMetadata.
+        Tags stored in the ImageMetadata will be uploaded to the learning loop.
+        The function should return empty metadata if the detector is not initialized."""
 
     @abstractmethod
-    def batch_evaluate(self,
-                       images: List[bytes],
-                       tags: List[str],
-                       source: Optional[str] = None,
-                       creation_date: Optional[str] = None) -> ImagesMetadata:
+    def batch_evaluate(self, images: List[bytes]) -> ImagesMetadata:
         """Evaluate a batch of images and return the detections.
-        The object should return empty detections if it is not initialized"""
+        The resulting detections per image should be stored in the ImagesMetadata.
+        Tags stored in the ImagesMetadata will be uploaded to the learning loop.
+        The function should return empty metadata if the detector is not initialized."""

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -509,7 +509,7 @@ class DetectorNode(Node):
                              *,
                              camera_id: Optional[str] = None,
                              source: Optional[str] = None,
-                             autoupload: str,
+                             autoupload: Literal['filtered', 'all', 'disabled'],
                              creation_date: Optional[str] = None) -> ImageMetadata:
         """ Main processing function for the detector node when an image is received via REST or SocketIO.
         This function infers the detections from the image, cares about uploading to the loop and returns the detections as ImageMetadata object.

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -575,10 +575,16 @@ class DetectorNode(Node):
             upload_priority: bool = False
     ) -> None:
         """Save images to the outbox using an asyncio executor.
-        Used by SIO and REST upload endpoints."""
+        Used by SIO and REST upload endpoints.
 
-        if images_metadata is not None and len(images_metadata.items) != len(images):
-            raise Exception('Number of images and number of metadata items do not match')
+        :param images: List of images to upload
+        :param images_metadata: Optional metadata for all images
+        :param upload_priority: Whether to upload the images with priority
+        :raises ValueError: If the number of images and number of metadata items do not match
+        """
+
+        if images_metadata and len(images_metadata.items) != len(images):
+            raise ValueError('Number of images and number of metadata items do not match')
 
         for i, image in enumerate(images):
             image_metadata = images_metadata.items[i] if images_metadata else ImageMetadata()

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional
 
 try:
     from typing import Literal
-except ImportError:  # Python < 3.8
+except ImportError:  # Python <= 3.8
     from typing_extensions import Literal  # type: ignore
 
 import socketio

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -228,7 +228,7 @@ class DetectorNode(Node):
             try:
                 det = await self.get_detections(
                     raw_image=data['image'],
-                    camera_id=data.get('camera-id', None),
+                    camera_id=data.get('camera_id', None),
                     tags=data.get('tags', []),
                     source=data.get('source', None),
                     autoupload=data.get('autoupload', 'filtered'),
@@ -250,7 +250,7 @@ class DetectorNode(Node):
                 det = await self.get_batch_detections(
                     raw_images=data['images'],
                     tags=data.get('tags', []),
-                    camera_id=data.get('camera-id', None),
+                    camera_id=data.get('camera_id', None),
                     source=data.get('source', None),
                     autoupload=data.get('autoupload', 'filtered'),
                     creation_date=data.get('creation_date', None)

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -305,13 +305,16 @@ class DetectorNode(Node):
             self.log.debug('Processing upload via socketio.')
 
             metadata = data.get('metadata', None)
-            if metadata and self.detector_logic.model_info is not None:
+            if metadata:
                 try:
                     image_metadata = from_dict(data_class=ImageMetadata, data=metadata)
                 except Exception as e:
                     self.log.exception('could not parse detections')
                     return {'error': str(e)}
-                image_metadata = self.add_category_id_to_detections(self.detector_logic.model_info, image_metadata)
+                if self.detector_logic.model_info is not None:
+                    image_metadata = self.add_category_id_to_detections(self.detector_logic.model_info, image_metadata)
+            else:
+                image_metadata = ImageMetadata()
 
             try:
                 await self.upload_images(

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -223,7 +223,7 @@ class DetectorNode(Node):
             try:
                 det = await self.get_detections(
                     raw_image=data['image'],
-                    camera_id=data.get('camera-id', None) or data.get('mac', None),
+                    camera_id=data.get('camera-id', None),
                     tags=data.get('tags', []),
                     source=data.get('source', None),
                     autoupload=data.get('autoupload', 'filtered'),
@@ -245,7 +245,7 @@ class DetectorNode(Node):
                 det = await self.get_batch_detections(
                     raw_images=data['images'],
                     tags=data.get('tags', []),
-                    camera_id=data.get('camera-id', None) or data.get('mac', None),
+                    camera_id=data.get('camera-id', None),
                     source=data.get('source', None),
                     autoupload=data.get('autoupload', 'filtered'),
                     creation_date=data.get('creation_date', None)
@@ -296,7 +296,12 @@ class DetectorNode(Node):
 
         @self.sio.event
         async def upload(sid, data: Dict) -> Dict:
-            """Upload a single image with metadata to the learning loop."""
+            """Upload a single image with metadata to the learning loop.
+
+            The data dict must contain:
+            - image: The image bytes to upload
+            - metadata: The metadata for the image (optional)
+            """
             self.log.debug('Processing upload via socketio.')
 
             metadata = data.get('metadata', None)

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -549,8 +549,7 @@ class DetectorNode(Node):
             n_po, n_se = len(detections.point_detections), len(detections.segmentation_detections)
             self.log.debug('Detected: %d boxes, %d points, %d segs, %d classes', n_bo, n_po, n_se, n_cl)
 
-            autoupload = autoupload or 'filtered'
-            if autoupload == 'filtered' and camera_id is not None:
+            if autoupload == 'filtered':
                 camera_id = camera_id or 'unknown'
                 background_tasks.create(self.relevance_filter.may_upload_detections(detections, camera_id, raw_image))
             elif autoupload == 'all':

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -522,7 +522,10 @@ class DetectorNode(Node):
         It can be converted e.g. using cv2.imdecode(np.frombuffer(image, np.uint8), cv2.IMREAD_COLOR)"""
 
         await self.detection_lock.acquire()
-        metadata = await run.io_bound(self.detector_logic.evaluate, raw_image, tags, source, creation_date)
+        metadata = await run.io_bound(self.detector_logic.evaluate, raw_image)
+        metadata.tags.extend(tags)
+        metadata.source = source
+        metadata.created = creation_date
         self.detection_lock.release()
 
         fix_shape_detections(metadata)
@@ -552,7 +555,7 @@ class DetectorNode(Node):
         This function infers the detections from all images, cares about uploading to the loop and returns the detections as a list of ImageMetadata."""
 
         await self.detection_lock.acquire()
-        all_detections = await run.io_bound(self.detector_logic.batch_evaluate, raw_images, tags, source=source, creation_date=creation_date)
+        all_detections = await run.io_bound(self.detector_logic.batch_evaluate, raw_images)
         self.detection_lock.release()
 
         for detections, raw_image in zip(all_detections.items, raw_images):

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -8,6 +8,11 @@ from dataclasses import asdict
 from datetime import datetime
 from typing import Dict, List, Optional
 
+try:
+    from typing import Literal
+except ImportError:  # Python < 3.8
+    from typing_extensions import Literal  # type: ignore
+
 import socketio
 from dacite import from_dict
 from fastapi.encoders import jsonable_encoder

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -506,7 +506,7 @@ class DetectorNode(Node):
         """ Main processing function for the detector node when an image is received via REST or SocketIO.
         This function infers the detections from the image, cares about uploading to the loop and returns the detections as ImageMetadata object.
         Note: raw_image is a numpy array of type uint8, but not in the correct shape!
-        It can be converted e.g. using cv2.imdecode(raw_image, cv2.IMREAD_COLOR)"""
+        It can be converted e.g. using cv2.imdecode(np.frombuffer(image, np.uint8), cv2.IMREAD_COLOR)"""
 
         await self.detection_lock.acquire()
         metadata = await run.io_bound(self.detector_logic.evaluate, raw_image, tags, source, creation_date)
@@ -614,9 +614,9 @@ def step_into(new_dir):
         os.chdir(previous_dir)
 
 
-def fix_shape_detections(detections: ImageMetadata):
+def fix_shape_detections(metadata: ImageMetadata):
     # TODO This is a quick fix.. check how loop upload detections deals with this
-    for seg_detection in detections.segmentation_detections:
+    for seg_detection in metadata.segmentation_detections:
         if isinstance(seg_detection.shape, Shape):
             points = ','.join([str(value) for p in seg_detection.shape.points for _,
                                value in asdict(p).items()])

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -531,7 +531,6 @@ class DetectorNode(Node):
         self.log.debug('Detected: %d boxes, %d points, %d segs, %d classes', n_bo, n_po, n_se, n_cl)
 
         if autoupload == 'filtered':
-            camera_id = camera_id or 'unknown'
             background_tasks.create(self.relevance_filter.may_upload_detections(metadata, camera_id, raw_image))
         elif autoupload == 'all':
             background_tasks.create(self.outbox.save(raw_image, metadata))
@@ -563,7 +562,6 @@ class DetectorNode(Node):
             self.log.debug('Detected: %d boxes, %d points, %d segs, %d classes', n_bo, n_po, n_se, n_cl)
 
             if autoupload == 'filtered':
-                camera_id = camera_id or 'unknown'
                 background_tasks.create(self.relevance_filter.may_upload_detections(detections, camera_id, raw_image))
             elif autoupload == 'all':
                 background_tasks.create(self.outbox.save(raw_image, detections))

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -509,7 +509,7 @@ class DetectorNode(Node):
                              *,
                              camera_id: Optional[str] = None,
                              source: Optional[str] = None,
-                             autoupload: str = 'filtered',
+                             autoupload: str,
                              creation_date: Optional[str] = None) -> ImageMetadata:
         """ Main processing function for the detector node when an image is received via REST or SocketIO.
         This function infers the detections from the image, cares about uploading to the loop and returns the detections as ImageMetadata object.

--- a/learning_loop_node/detector/inbox_filter/relevance_filter.py
+++ b/learning_loop_node/detector/inbox_filter/relevance_filter.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from ...data_classes.image_metadata import ImageMetadata
 from ..outbox import Outbox
@@ -9,11 +9,12 @@ class RelevanceFilter():
 
     def __init__(self, outbox: Outbox) -> None:
         self.cam_histories: Dict[str, CamObservationHistory] = {}
+        self.unknown_cam_history: CamObservationHistory = CamObservationHistory()
         self.outbox: Outbox = outbox
 
     async def may_upload_detections(self,
                                     image_metadata: ImageMetadata,
-                                    cam_id: str,
+                                    cam_id: Optional[str],
                                     raw_image: bytes) -> List[str]:
         """Check if the detection should be uploaded to the outbox.
         If so, upload it and return the list of causes for the upload.
@@ -21,9 +22,14 @@ class RelevanceFilter():
         for group in self.cam_histories.values():
             group.forget_old_detections()
 
-        if cam_id not in self.cam_histories:
-            self.cam_histories[cam_id] = CamObservationHistory()
-        causes = self.cam_histories[cam_id].get_causes_to_upload(image_metadata)
+        if cam_id is None:
+            history = self.unknown_cam_history
+        else:
+            if cam_id not in self.cam_histories:
+                self.cam_histories[cam_id] = CamObservationHistory()
+            history = self.cam_histories[cam_id]
+
+        causes = history.get_causes_to_upload(image_metadata)
         if len(image_metadata) >= 80:
             causes.append('unexpected_observations_count')
         if len(causes) > 0:

--- a/learning_loop_node/detector/inbox_filter/relevance_filter.py
+++ b/learning_loop_node/detector/inbox_filter/relevance_filter.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from ...data_classes.image_metadata import ImageMetadata
 from ..outbox import Outbox
@@ -14,10 +14,7 @@ class RelevanceFilter():
     async def may_upload_detections(self,
                                     image_metadata: ImageMetadata,
                                     cam_id: str,
-                                    raw_image: bytes,
-                                    tags: List[str],
-                                    source: Optional[str] = None,
-                                    creation_date: Optional[str] = None) -> List[str]:
+                                    raw_image: bytes) -> List[str]:
         """Check if the detection should be uploaded to the outbox.
         If so, upload it and return the list of causes for the upload.
         """
@@ -30,7 +27,6 @@ class RelevanceFilter():
         if len(image_metadata) >= 80:
             causes.append('unexpected_observations_count')
         if len(causes) > 0:
-            tags = tags if tags is not None else []
-            tags.extend(causes)
-            await self.outbox.save(raw_image, image_metadata, tags, source, creation_date)
+            image_metadata.tags.extend(causes)
+            await self.outbox.save(raw_image, image_metadata)
         return causes

--- a/learning_loop_node/detector/rest/detect.py
+++ b/learning_loop_node/detector/rest/detect.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 from fastapi import APIRouter, File, Header, Request, UploadFile
 
@@ -18,8 +18,8 @@ async def http_detect(
     camera_id: Optional[str] = Header(None, description='The camera id (used by learning loop)'),
     tags: Optional[str] = Header(None, description='Tags to add to the image (used by learning loop)'),
     source: Optional[str] = Header(None, description='The source of the image (used by learning loop)'),
-    autoupload: Optional[str] = Header(None, description='Mode to decide whether to upload the image to the learning loop',
-                                       examples=['filtered', 'all', 'disabled']),
+    autoupload: Optional[Literal['filtered', 'all', 'disabled']] = Header(None, description='Mode to decide whether to upload the image to the learning loop',
+                                                                          examples=['filtered', 'all', 'disabled']),
     creation_date: Optional[str] = Header(None, description='The creation date of the image (used by learning loop)')
 ):
     """

--- a/learning_loop_node/detector/rest/detect.py
+++ b/learning_loop_node/detector/rest/detect.py
@@ -45,7 +45,7 @@ async def http_detect(
                                               camera_id=camera_id or None,
                                               tags=tags.split(',') if tags else [],
                                               source=source,
-                                              autoupload=autoupload,
+                                              autoupload=autoupload or 'filtered',
                                               creation_date=creation_date)
     except Exception as exc:
         logging.exception('Error during detection of image %s.', file.filename)

--- a/learning_loop_node/detector/rest/detect.py
+++ b/learning_loop_node/detector/rest/detect.py
@@ -16,7 +16,6 @@ async def http_detect(
     request: Request,
     file: UploadFile = File(..., description='The image file to run detection on'),
     camera_id: Optional[str] = Header(None, description='The camera id (used by learning loop)'),
-    mac: Optional[str] = Header(None, description='The camera mac address (used by learning loop)'),
     tags: Optional[str] = Header(None, description='Tags to add to the image (used by learning loop)'),
     source: Optional[str] = Header(None, description='The source of the image (used by learning loop)'),
     autoupload: Optional[str] = Header(None, description='Mode to decide whether to upload the image to the learning loop',
@@ -43,7 +42,7 @@ async def http_detect(
     try:
         app: 'DetectorNode' = request.app
         detections = await app.get_detections(raw_image=file_bytes,
-                                              camera_id=camera_id or mac or None,
+                                              camera_id=camera_id or None,
                                               tags=tags.split(',') if tags else [],
                                               source=source,
                                               autoupload=autoupload,

--- a/learning_loop_node/detector/rest/detect.py
+++ b/learning_loop_node/detector/rest/detect.py
@@ -30,7 +30,7 @@ async def http_detect(
     """
     Single image example:
 
-        curl --request POST -F 'file=@test.jpg' localhost:8004/detect -H 'autoupload: all' -H 'camera-id: front_cam' -H 'source: test' -H 'tags: test,test2'
+        curl --request POST -F 'file=@test.jpg' localhost:8004/detect -H 'autoupload: all' -H 'camera_id: front_cam' -H 'source: test' -H 'tags: test,test2'
 
     Multiple images example:
 

--- a/learning_loop_node/detector/rest/detect.py
+++ b/learning_loop_node/detector/rest/detect.py
@@ -1,5 +1,10 @@
 import logging
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Optional
+
+try:
+    from typing import Literal
+except ImportError:  # Python <= 3.8
+    from typing_extensions import Literal  # type: ignore
 
 from fastapi import APIRouter, File, Header, Request, UploadFile
 

--- a/learning_loop_node/detector/rest/upload.py
+++ b/learning_loop_node/detector/rest/upload.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, List, Optional
 
 from fastapi import APIRouter, File, Query, Request, UploadFile
 
+from ...data_classes.image_metadata import ImageMetadata, ImagesMetadata
+
 if TYPE_CHECKING:
     from ..detector_node import DetectorNode
 
@@ -25,6 +27,14 @@ async def upload_image(request: Request,
         curl -X POST -F 'files=@test.jpg' "http://localhost:/upload?source=test&creation_date=2024-01-01T00:00:00&upload_priority=true"
     """
     raw_files = [await file.read() for file in files]
+    image_metadatas = []
+    for _ in files:
+        image_metadatas.append(ImageMetadata(source=source, created=creation_date))
+
+    images_metadata = ImagesMetadata(items=image_metadatas)
+
     node: DetectorNode = request.app
-    await node.upload_images(images=raw_files, source=source, creation_date=creation_date, upload_priority=upload_priority)
+    await node.upload_images(images=raw_files,
+                             images_metadata=images_metadata,
+                             upload_priority=upload_priority)
     return 200, "OK"

--- a/learning_loop_node/helpers/background_tasks.py
+++ b/learning_loop_node/helpers/background_tasks.py
@@ -21,7 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""inspired from https://quantlane.com/blog/ensure-asyncio-task-exceptions-get-logged/"""
 from __future__ import annotations
 
 import asyncio

--- a/learning_loop_node/tests/detector/conftest.py
+++ b/learning_loop_node/tests/detector/conftest.py
@@ -137,10 +137,7 @@ class MockDetectorLogic(DetectorLogic):  # pylint: disable=abstract-method
                                          x=0, y=0, width=10, height=10,
                                          model_name="mock", )])
 
-    def evaluate(self, image: bytes, tags: List[str], source: Optional[str] = None, creation_date: Optional[str] = None):
-        self.image_metadata.tags = tags
-        self.image_metadata.source = source
-        self.image_metadata.created = creation_date
+    def evaluate(self, image: bytes) -> ImageMetadata:
         return self.image_metadata
 
 

--- a/learning_loop_node/tests/detector/conftest.py
+++ b/learning_loop_node/tests/detector/conftest.py
@@ -135,10 +135,12 @@ class MockDetectorLogic(DetectorLogic):  # pylint: disable=abstract-method
                                          category_id="1",
                                          confidence=0.9,
                                          x=0, y=0, width=10, height=10,
-                                         model_name="mock",
-                                         )])
+                                         model_name="mock", )])
 
-    def evaluate_with_all_info(self, image: np.ndarray, tags: List[str], source: Optional[str] = None, creation_date: Optional[str] = None):
+    def evaluate(self, image: bytes, tags: List[str], source: Optional[str] = None, creation_date: Optional[str] = None):
+        self.image_metadata.tags = tags
+        self.image_metadata.source = source
+        self.image_metadata.created = creation_date
         return self.image_metadata
 
 

--- a/learning_loop_node/tests/detector/inbox_filter/test_unexpected_observations_count.py
+++ b/learning_loop_node/tests/detector/inbox_filter/test_unexpected_observations_count.py
@@ -16,7 +16,7 @@ l_conf_point_det = PointDetection(category_name='point', x=100, y=100,
 
 
 @pytest.mark.parametrize(
-    "detections,reason",
+    "metadata,reason",
     [(ImageMetadata(box_detections=[h_conf_box_det] * 40, point_detections=[h_conf_point_det] * 40),
       ['unexpected_observations_count']),
      (ImageMetadata(box_detections=[h_conf_box_det], point_detections=[h_conf_point_det]), []),
@@ -25,10 +25,10 @@ l_conf_point_det = PointDetection(category_name='point', x=100, y=100,
      (ImageMetadata(box_detections=[h_conf_box_det], point_detections=[l_conf_point_det]),
       ['uncertain'])])
 @pytest.mark.asyncio
-async def test_unexpected_observations_count(detections: ImageMetadata, reason: List[str]):
+async def test_unexpected_observations_count(metadata: ImageMetadata, reason: List[str]):
     os.environ['LOOP_ORGANIZATION'] = 'zauberzeug'
     os.environ['LOOP_PROJECT'] = 'demo'
     outbox = Outbox()
 
     relevance_filter = RelevanceFilter(outbox)
-    assert await relevance_filter.may_upload_detections(detections, raw_image=b'', cam_id='0:0:0:0', tags=[]) == reason
+    assert await relevance_filter.may_upload_detections(metadata, raw_image=b'', cam_id='0:0:0:0') == reason

--- a/learning_loop_node/tests/detector/test_detector_node.py
+++ b/learning_loop_node/tests/detector/test_detector_node.py
@@ -1,3 +1,5 @@
+from typing import List, Literal, Tuple
+
 import numpy as np
 import pytest
 
@@ -15,11 +17,11 @@ async def test_get_detections(detector_node: DetectorNode, monkeypatch):
 
     save_args = []
 
-    def mock_filtered_upload(*args, **kwargs):  # pylint: disable=unused-argument
+    async def mock_filtered_upload(*args, **kwargs):  # pylint: disable=unused-argument
         nonlocal filtered_upload_called
         filtered_upload_called = True
 
-    def mock_save(*args, **kwargs):
+    async def mock_save(*args, **kwargs):
         nonlocal save_called
         nonlocal save_args
         save_called = True
@@ -30,7 +32,7 @@ async def test_get_detections(detector_node: DetectorNode, monkeypatch):
     monkeypatch.setattr(detector_node.outbox, "save", mock_save)
 
     # Test cases
-    test_cases = [
+    test_cases: List[Tuple[Literal['filtered', 'all', 'disabled'], bool, bool]] = [
         ("filtered", True, False),
         ("all", False, True),
         ("disabled", False, False),

--- a/learning_loop_node/tests/detector/test_relevance_filter.py
+++ b/learning_loop_node/tests/detector/test_relevance_filter.py
@@ -13,7 +13,7 @@ file_path = os.path.abspath(__file__)
 test_image_path = os.path.join(os.path.dirname(file_path), 'test.jpg')
 
 
-@pytest.mark.parametrize('autoupload, expected_file_count', [(None, 2), ('all', 4)])
+@pytest.mark.parametrize('autoupload, expected_file_count', [('filtered', 2), ('all', 4)])
 async def test_filter_is_used_by_node(test_detector_node: DetectorNode, autoupload, expected_file_count):
     """Test if filtering is used by the node. In particular, when upload is filtered, the identical detections should not be uploaded twice.
     Note thatt we have to mock the dummy detections to only return a point and a box detection."""

--- a/learning_loop_node/tests/detector/testing_detector.py
+++ b/learning_loop_node/tests/detector/testing_detector.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import List
 
 from learning_loop_node.data_classes import ImagesMetadata
 
@@ -18,17 +18,9 @@ class TestingDetectorLogic(DetectorLogic):
     def init(self) -> None:
         pass
 
-    def evaluate(self,
-                 image: bytes,
-                 tags: List[str],
-                 source: Optional[str] = None,
-                 creation_date: Optional[str] = None) -> ImageMetadata:
+    def evaluate(self, image: bytes) -> ImageMetadata:
         logging.info('evaluating')
         return self.det_to_return
 
-    def batch_evaluate(self,
-                       images: List[bytes],
-                       tags: List[str],
-                       source: Optional[str] = None,
-                       creation_date: Optional[str] = None) -> ImagesMetadata:
+    def batch_evaluate(self, images: List[bytes]) -> ImagesMetadata:
         raise NotImplementedError()

--- a/learning_loop_node/tests/detector/testing_detector.py
+++ b/learning_loop_node/tests/detector/testing_detector.py
@@ -29,6 +29,6 @@ class TestingDetectorLogic(DetectorLogic):
     def batch_evaluate(self,
                        images: List[bytes],
                        tags: List[str],
-                       source: str | None = None,
-                       creation_date: str | None = None) -> ImagesMetadata:
+                       source: Optional[str] = None,
+                       creation_date: Optional[str] = None) -> ImagesMetadata:
         raise NotImplementedError()

--- a/learning_loop_node/tests/detector/testing_detector.py
+++ b/learning_loop_node/tests/detector/testing_detector.py
@@ -1,10 +1,11 @@
 import logging
+from typing import List, Optional
 
-import numpy as np
+from learning_loop_node.data_classes import ImagesMetadata
 
 from ...data_classes import ImageMetadata
 from ...detector.detector_logic import DetectorLogic
-from ..test_helper import get_dummy_detections
+from ..test_helper import get_dummy_metadata
 
 
 class TestingDetectorLogic(DetectorLogic):
@@ -12,11 +13,22 @@ class TestingDetectorLogic(DetectorLogic):
 
     def __init__(self) -> None:
         super().__init__('mocked')
-        self.det_to_return: ImageMetadata = get_dummy_detections()
+        self.det_to_return: ImageMetadata = get_dummy_metadata()
 
     def init(self) -> None:
         pass
 
-    def evaluate(self, image: np.ndarray) -> ImageMetadata:
+    def evaluate(self,
+                 image: bytes,
+                 tags: List[str],
+                 source: Optional[str] = None,
+                 creation_date: Optional[str] = None) -> ImageMetadata:
         logging.info('evaluating')
         return self.det_to_return
+
+    def batch_evaluate(self,
+                       images: List[bytes],
+                       tags: List[str],
+                       source: str | None = None,
+                       creation_date: str | None = None) -> ImagesMetadata:
+        raise NotImplementedError()

--- a/learning_loop_node/tests/test_helper.py
+++ b/learning_loop_node/tests/test_helper.py
@@ -70,25 +70,7 @@ def _update_attribute_dict(obj: dict, **kwargs) -> None:
         obj[key] = value
 
 
-def get_dummy_metadata() -> ImageMetadata:
-    return ImageMetadata(
-        box_detections=[
-            BoxDetection(category_name='some_category_name', x=1, y=2, height=3, width=4,
-                         model_name='some_model', confidence=.42, category_id='some_id')],
-        point_detections=[
-            PointDetection(category_name='some_category_name_2', x=10, y=12,
-                           model_name='some_model', confidence=.42, category_id='some_id_2')],
-        segmentation_detections=[
-            SegmentationDetection(category_name='some_category_name_3',
-                                  shape=Shape(points=[Point(x=1, y=1)]),
-                                  model_name='some_model', confidence=.42,
-                                  category_id='some_id_3')],
-        classification_detections=[
-            ClassificationDetection(category_name='some_category_name_4', model_name='some_model',
-                                    confidence=.42, category_id='some_id_4')])
-
-
-def get_dummy_dets() -> Detections:
+def get_dummy_detections() -> Detections:
     return Detections(
         box_detections=[
             BoxDetection(category_name='some_category_name', x=1, y=2, height=3, width=4,
@@ -104,3 +86,11 @@ def get_dummy_dets() -> Detections:
         classification_detections=[
             ClassificationDetection(category_name='some_category_name_4', model_name='some_model',
                                     confidence=.42, category_id='some_id_4')])
+
+
+def get_dummy_metadata() -> ImageMetadata:
+    detections = get_dummy_detections()
+    return ImageMetadata(box_detections=detections.box_detections,
+                         point_detections=detections.point_detections,
+                         segmentation_detections=detections.segmentation_detections,
+                         classification_detections=detections.classification_detections)

--- a/learning_loop_node/tests/test_helper.py
+++ b/learning_loop_node/tests/test_helper.py
@@ -6,8 +6,16 @@ import zipfile
 from glob import glob
 from typing import Callable
 
-from ..data_classes import (BoxDetection, ClassificationDetection, Detections, Point, PointDetection,
-                            SegmentationDetection, Shape)
+from ..data_classes import (
+    BoxDetection,
+    ClassificationDetection,
+    Detections,
+    Point,
+    PointDetection,
+    SegmentationDetection,
+    Shape,
+)
+from ..data_classes.image_metadata import ImageMetadata
 from ..loop_communication import LoopCommunicator
 
 
@@ -62,7 +70,25 @@ def _update_attribute_dict(obj: dict, **kwargs) -> None:
         obj[key] = value
 
 
-def get_dummy_detections():
+def get_dummy_metadata() -> ImageMetadata:
+    return ImageMetadata(
+        box_detections=[
+            BoxDetection(category_name='some_category_name', x=1, y=2, height=3, width=4,
+                         model_name='some_model', confidence=.42, category_id='some_id')],
+        point_detections=[
+            PointDetection(category_name='some_category_name_2', x=10, y=12,
+                           model_name='some_model', confidence=.42, category_id='some_id_2')],
+        segmentation_detections=[
+            SegmentationDetection(category_name='some_category_name_3',
+                                  shape=Shape(points=[Point(x=1, y=1)]),
+                                  model_name='some_model', confidence=.42,
+                                  category_id='some_id_3')],
+        classification_detections=[
+            ClassificationDetection(category_name='some_category_name_4', model_name='some_model',
+                                    confidence=.42, category_id='some_id_4')])
+
+
+def get_dummy_dets() -> Detections:
     return Detections(
         box_detections=[
             BoxDetection(category_name='some_category_name', x=1, y=2, height=3, width=4,

--- a/learning_loop_node/tests/trainer/states/test_state_detecting.py
+++ b/learning_loop_node/tests/trainer/states/test_state_detecting.py
@@ -2,7 +2,7 @@ import asyncio
 
 from ....enums import TrainerState
 from ....trainer.trainer_logic import TrainerLogic
-from ...test_helper import get_dummy_dets
+from ...test_helper import get_dummy_detections
 from ..state_helper import assert_training_state, create_active_training_file
 from ..testing_trainer_logic import TestingTrainerLogic
 
@@ -71,7 +71,7 @@ def test_save_load_detections(test_initialized_trainer: TestingTrainerLogic):
     create_active_training_file(trainer)
     trainer._init_from_last_training()
 
-    detections = [get_dummy_dets(), get_dummy_dets()]
+    detections = [get_dummy_detections(), get_dummy_detections()]
 
     trainer.active_training_io.save_detections(detections)
     assert trainer.active_training_io.detections_exist()

--- a/learning_loop_node/tests/trainer/states/test_state_detecting.py
+++ b/learning_loop_node/tests/trainer/states/test_state_detecting.py
@@ -2,7 +2,7 @@ import asyncio
 
 from ....enums import TrainerState
 from ....trainer.trainer_logic import TrainerLogic
-from ...test_helper import get_dummy_detections
+from ...test_helper import get_dummy_dets
 from ..state_helper import assert_training_state, create_active_training_file
 from ..testing_trainer_logic import TestingTrainerLogic
 
@@ -16,7 +16,8 @@ def trainer_has_detecting_error(trainer: TrainerLogic):
 async def test_successful_detecting(test_initialized_trainer: TestingTrainerLogic):
     trainer = test_initialized_trainer
     create_active_training_file(trainer, training_state='train_model_uploaded',
-                                model_uuid_for_detecting='00000000-0000-0000-0000-000000000011')  # NOTE: this is the hard coded model uuid for zauberzeug/demo (model version 1.1)
+                                # NOTE: this is the hard coded model uuid for zauberzeug/demo (model version 1.1)
+                                model_uuid_for_detecting='00000000-0000-0000-0000-000000000011')
 
     _ = asyncio.get_running_loop().create_task(
         trainer._perform_state('detecting', TrainerState.Detecting, TrainerState.Detected, trainer._do_detections))
@@ -70,7 +71,7 @@ def test_save_load_detections(test_initialized_trainer: TestingTrainerLogic):
     create_active_training_file(trainer)
     trainer._init_from_last_training()
 
-    detections = [get_dummy_detections(), get_dummy_detections()]
+    detections = [get_dummy_dets(), get_dummy_dets()]
 
     trainer.active_training_io.save_detections(detections)
     assert trainer.active_training_io.detections_exist()

--- a/learning_loop_node/tests/trainer/states/test_state_upload_detections.py
+++ b/learning_loop_node/tests/trainer/states/test_state_upload_detections.py
@@ -7,7 +7,7 @@ from ....data_classes import BoxDetection, Context, Detections
 from ....enums import TrainerState
 from ....loop_communication import LoopCommunicator
 from ....trainer.trainer_logic import TrainerLogic
-from ...test_helper import get_dummy_dets
+from ...test_helper import get_dummy_detections
 from ..state_helper import assert_training_state, create_active_training_file
 from ..testing_trainer_logic import TestingTrainerLogic
 
@@ -123,7 +123,7 @@ async def test_bad_status_from_LearningLoop(test_initialized_trainer: TestingTra
     create_active_training_file(trainer, training_state=TrainerState.Detected, context=Context(
         organization='zauberzeug', project='some_bad_project'))
     trainer._init_from_last_training()
-    trainer.active_training_io.save_detections([get_dummy_dets()])
+    trainer.active_training_io.save_detections([get_dummy_detections()])
 
     trainer._begin_training_task()
     await assert_training_state(trainer.training, TrainerState.DetectionUploading, timeout=1, interval=0.001)

--- a/learning_loop_node/tests/trainer/states/test_state_upload_detections.py
+++ b/learning_loop_node/tests/trainer/states/test_state_upload_detections.py
@@ -7,7 +7,7 @@ from ....data_classes import BoxDetection, Context, Detections
 from ....enums import TrainerState
 from ....loop_communication import LoopCommunicator
 from ....trainer.trainer_logic import TrainerLogic
-from ...test_helper import get_dummy_detections
+from ...test_helper import get_dummy_dets
 from ..state_helper import assert_training_state, create_active_training_file
 from ..testing_trainer_logic import TestingTrainerLogic
 
@@ -123,7 +123,7 @@ async def test_bad_status_from_LearningLoop(test_initialized_trainer: TestingTra
     create_active_training_file(trainer, training_state=TrainerState.Detected, context=Context(
         organization='zauberzeug', project='some_bad_project'))
     trainer._init_from_last_training()
-    trainer.active_training_io.save_detections([get_dummy_detections()])
+    trainer.active_training_io.save_detections([get_dummy_dets()])
 
     trainer._begin_training_task()
     await assert_training_state(trainer.training, TrainerState.DetectionUploading, timeout=1, interval=0.001)

--- a/mock_detector/app_code/mock_detector.py
+++ b/mock_detector/app_code/mock_detector.py
@@ -21,6 +21,6 @@ class MockDetector(DetectorLogic):
     def batch_evaluate(self,
                        images: List[bytes],
                        tags: List[str],
-                       source: str | None = None,
-                       creation_date: str | None = None) -> ImagesMetadata:
+                       source: Optional[str] = None,
+                       creation_date: Optional[str] = None) -> ImagesMetadata:
         raise NotImplementedError()

--- a/mock_detector/app_code/mock_detector.py
+++ b/mock_detector/app_code/mock_detector.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from learning_loop_node.data_classes import ImageMetadata, ImagesMetadata
 from learning_loop_node.detector.detector_logic import DetectorLogic
@@ -11,16 +11,8 @@ class MockDetector(DetectorLogic):
     def init(self) -> None:
         pass
 
-    def evaluate(self,
-                 image: bytes,
-                 tags: List[str],
-                 source: Optional[str] = None,
-                 creation_date: Optional[str] = None) -> ImageMetadata:
+    def evaluate(self, image: bytes) -> ImageMetadata:
         return ImageMetadata()
 
-    def batch_evaluate(self,
-                       images: List[bytes],
-                       tags: List[str],
-                       source: Optional[str] = None,
-                       creation_date: Optional[str] = None) -> ImagesMetadata:
+    def batch_evaluate(self, images: List[bytes]) -> ImagesMetadata:
         raise NotImplementedError()

--- a/mock_detector/app_code/mock_detector.py
+++ b/mock_detector/app_code/mock_detector.py
@@ -1,6 +1,6 @@
-from typing import Any
+from typing import List, Optional
 
-from learning_loop_node.data_classes import ImageMetadata
+from learning_loop_node.data_classes import ImageMetadata, ImagesMetadata
 from learning_loop_node.detector.detector_logic import DetectorLogic
 
 
@@ -11,5 +11,16 @@ class MockDetector(DetectorLogic):
     def init(self) -> None:
         pass
 
-    def evaluate(self, image: Any) -> ImageMetadata:
+    def evaluate(self,
+                 image: bytes,
+                 tags: List[str],
+                 source: Optional[str] = None,
+                 creation_date: Optional[str] = None) -> ImageMetadata:
         return ImageMetadata()
+
+    def batch_evaluate(self,
+                       images: List[bytes],
+                       tags: List[str],
+                       source: str | None = None,
+                       creation_date: str | None = None) -> ImagesMetadata:
+        raise NotImplementedError()

--- a/node.code-workspace
+++ b/node.code-workspace
@@ -7,10 +7,10 @@
   "settings": {
     "window.title": "### NODE LIBRARY ### ${activeEditorShort}${separator}${rootName} ### NODE LIBRARY ###",
     "workbench.colorCustomizations": {
-      "titleBar.activeBackground": "#eee5ca",
+      "titleBar.activeBackground": "#858467",
       "titleBar.activeForeground": "#FFFFFF",
-      "statusBar.background": "#eee5ca",
-      "activityBar.background": "#eee5ca",
+      "statusBar.background": "#858467",
+      "activityBar.background": "#858467",
       "activityBar.foreground": "#FFFFFF"
     }
   },


### PR DESCRIPTION
## Motivation
Simplify API and internal processing. Allow to provide detections when uploading images.

## Fixes
- Filtered upload required camera_id, now it works without it

## Breaking changes
- remove `mac` parameter from REST detect EP (was only used as fallback for `camera_id`)
- `detector_logic` now has to implement `evaluate` only and has to transfer tags, source and creation_date to the meta_data