### PR TITLE
Redesign DetectorLogic to allow parallel detections and model updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ learning_loop_node/tmp
 learning_loop_node/.python-version
 
 learning_loop_node.egg-info/
+
+.claude/*local*

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You can configure connection to our Learning Loop by specifying the following en
 | LOOP_PROJECT             | PROJECT      | Project ID                                                   | Detector (opt.)           |
 | MIN_UNCERTAIN_THRESHOLD  | -            | smallest confidence (float) at which auto-upload will happen | Detector (opt.)           |
 | MAX_UNCERTAIN_THRESHOLD  | -            | largest confidence (float) at which auto-upload will happen  | Detector (opt.)           |
+| EXCLUSIVE_MODEL_BUILD    | -            | Reject detections during update to save VRAM (set to 0)      | Detector (opt.)           |
 | INFERENCE_BATCH_SIZE     | -            | Batch size of trainer when calculating detections            | Trainer (opt.)            |
 | RESTART_AFTER_TRAINING   | -            | Restart the trainer after training (set to 1)                | Trainer (opt.)            |
 | KEEP_OLD_TRAININGS       | -            | Do not delete old trainings (set to 1)                       | Trainer (opt.)            |

--- a/README.md
+++ b/README.md
@@ -17,22 +17,22 @@ To start a node you have to implement the logic by inheriting from the correspon
 
 You can configure connection to our Learning Loop by specifying the following environment variables before starting:
 
-| Name                     | Alias        | Purpose                                                      | Required by               |
-| ------------------------ | ------------ | ------------------------------------------------------------ | ------------------------- |
-| LOOP_HOST                | HOST         | Learning Loop address (e.g. learning-loop.ai)                | all                       |
-| LOOP_USERNAME            | USERNAME     | Learning Loop user name                                      | all besides Detector      |
-| LOOP_PASSWORD            | PASSWORD     | Learning Loop password                                       | all besides Detector      |
-| LOOP_SSL_CERT_PATH       | -            | Path to the SSL certificate                                  | all (opt.)                |
-| LOOP_ORGANIZATION        | ORGANIZATION | Organization ID                                              | Detector                  |
-| LOOP_PROJECT             | PROJECT      | Project ID                                                   | Detector (opt.)           |
-| MIN_UNCERTAIN_THRESHOLD  | -            | smallest confidence (float) at which auto-upload will happen | Detector (opt.)           |
-| MAX_UNCERTAIN_THRESHOLD  | -            | largest confidence (float) at which auto-upload will happen  | Detector (opt.)           |
-| EXCLUSIVE_MODEL_BUILD    | -            | Reject detections during update to save VRAM (set to 0)      | Detector (opt.)           |
-| INFERENCE_BATCH_SIZE     | -            | Batch size of trainer when calculating detections            | Trainer (opt.)            |
-| RESTART_AFTER_TRAINING   | -            | Restart the trainer after training (set to 1)                | Trainer (opt.)            |
-| KEEP_OLD_TRAININGS       | -            | Do not delete old trainings (set to 1)                       | Trainer (opt.)            |
-| TRAINER_IDLE_TIMEOUT_SEC | -            | Automatically shutdown trainer after timeout (in seconds)    | Trainer (opt.)            |
-| USE_BACKDOOR_CONTROLS    | -            | Always enable backdoor controls (set to 1)                   | Trainer / Detector (opt.) |
+| Name                     | Alias        | Purpose                                                      | Required by               | Default      |
+| ------------------------ | ------------ | ------------------------------------------------------------ | ------------------------- | ------------ |
+| LOOP_HOST                | HOST         | Learning Loop address (e.g. learning-loop.ai)                | all                       | -            |
+| LOOP_USERNAME            | USERNAME     | Learning Loop user name                                      | all besides Detector      | -            |
+| LOOP_PASSWORD            | PASSWORD     | Learning Loop password                                       | all besides Detector      | -            |
+| LOOP_SSL_CERT_PATH       | -            | Path to the SSL certificate                                  | all (opt.)                | -            |
+| LOOP_ORGANIZATION        | ORGANIZATION | Organization ID                                              | Detector                  | -            |
+| LOOP_PROJECT             | PROJECT      | Project ID                                                   | Detector                  | -            |
+| MIN_UNCERTAIN_THRESHOLD  | -            | smallest confidence (float) at which auto-upload will happen | Detector (opt.)           | 0.3          |
+| MAX_UNCERTAIN_THRESHOLD  | -            | largest confidence (float) at which auto-upload will happen  | Detector (opt.)           | 0.6          |
+| EXCLUSIVE_MODEL_BUILD    | -            | Reject detections during update to save VRAM (set to 1)      | Detector (opt.)           | 0            |
+| INFERENCE_BATCH_SIZE     | -            | Batch size of trainer when calculating detections            | Trainer (opt.)            | 10           |
+| RESTART_AFTER_TRAINING   | -            | Restart the trainer after training (set to 1)                | Trainer (opt.)            | 0            |
+| KEEP_OLD_TRAININGS       | -            | Do not delete old trainings (set to 1)                       | Trainer (opt.)            | 0            |
+| TRAINER_IDLE_TIMEOUT_SEC | -            | Automatically shutdown trainer after timeout (in seconds)    | Trainer (opt.)            | 0 (disabled) |
+| USE_BACKDOOR_CONTROLS    | -            | Always enable backdoor controls (set to 1)                   | Trainer / Detector (opt.) | 0            |
 
 Note that organization and project IDs are always lower case and may differ from the names in the Learning Loop which can have uppercase letters.
 
@@ -239,5 +239,5 @@ After a short time the converted model should be available as well.
   - `id`: the model UUID (currently not needed by anyone, since host, org, project, version clearly identify the model)
   - `format`: the format e.g. yolo, tkdnn, yolor etc.
 - Nodes add properties to `model.json`, which contains all the information which are needed by subsequent nodes. These are typically the properties:
-  - `resolution`: resolution in which the model expects images (as `int`, since the resolution is mostly square - later, ` resolution_x`` resolution_y ` would also be conceivable or `resolutions` to give a list of possible resolutions)
+  - `resolution`: resolution in which the model expects images (as `int`, since the resolution is mostly square - later, `resolution_x`` resolution_y` would also be conceivable or `resolutions` to give a list of possible resolutions)
   - `categories`: list of categories with name, id, (later also type), in the order in which they are used by the model -- this is neccessary to be robust about renamings

--- a/learning_loop_node/__init__.py
+++ b/learning_loop_node/__init__.py
@@ -1,11 +1,11 @@
 import logging
 
 # from . import log_conf
-from .detector.detector_logic import DetectorLogic
+from .detector.detector_logic import DetectorLogic, DetectorLogicFactory
 from .detector.detector_node import DetectorNode
 from .globals import GLOBALS
 from .trainer.trainer_node import TrainerNode
 
-__all__ = ['TrainerNode', 'DetectorNode', 'DetectorLogic', 'GLOBALS']
+__all__ = ['TrainerNode', 'DetectorNode', 'DetectorLogic', 'DetectorLogicFactory', 'GLOBALS']
 
 logging.info('>>>>>>>>>>>>>>>>>> LOOP INITIALIZED <<<<<<<<<<<<<<<<<<<<<<<')

--- a/learning_loop_node/detector/__init__.py
+++ b/learning_loop_node/detector/__init__.py
@@ -1,0 +1,6 @@
+from .detector_logic import DetectorLogic, DetectorLogicFactory
+
+__all__ = [
+    'DetectorLogic',
+    'DetectorLogicFactory',
+]

--- a/learning_loop_node/detector/detector_logic.py
+++ b/learning_loop_node/detector/detector_logic.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import List, Protocol
 
 import numpy as np
@@ -17,14 +16,13 @@ class DetectorLogicFactory(Protocol):
     async def build(self, model_info: ModelInformation) -> 'DetectorLogic': ...
 
 
-class DetectorLogic():
-    """Pure interface for detector implementations.
+class DetectorLogic(Protocol):
+    """Protocol for detector implementations.
 
-    Subclasses receive the ModelInformation via their constructor (called by the
+    Implementations receive the ModelInformation via their constructor (called by the
     DetectorLogic factory in DetectorNode) and are free to store or ignore it.
     """
 
-    @abstractmethod
     def evaluate(self, image: np.ndarray) -> ImageMetadata:
         """Evaluate the image and return the detections.
 
@@ -32,11 +30,12 @@ class DetectorLogic():
         The resulting detections should be stored in the ImageMetadata.
         Tags stored in the ImageMetadata will be uploaded to the learning loop.
         """
+        ...
 
-    @abstractmethod
     def batch_evaluate(self, images: List[np.ndarray]) -> ImagesMetadata:
         """Evaluate a batch of images and return the detections.
 
         The resulting detections per image should be stored in the ImagesMetadata.
         Tags stored in the ImagesMetadata will be uploaded to the learning loop.
         """
+        ...

--- a/learning_loop_node/detector/detector_logic.py
+++ b/learning_loop_node/detector/detector_logic.py
@@ -1,80 +1,42 @@
-import logging
 from abc import abstractmethod
-from typing import List, Optional
+from typing import List, Protocol
 
 import numpy as np
 
 from ..data_classes import ImageMetadata, ImagesMetadata, ModelInformation
-from ..globals import GLOBALS
-from .exceptions import NodeNeedsRestartError
+
+
+class DetectorLogicFactory(Protocol):
+    """Protocol for building DetectorLogic instances.
+
+    The factory controls how the detector is constructed — implementations
+    can build synchronously or offload heavy work to a thread pool.
+    """
+    model_format: str
+
+    async def build(self, model_info: ModelInformation) -> 'DetectorLogic': ...
 
 
 class DetectorLogic():
+    """Pure interface for detector implementations.
 
-    def __init__(self, model_format: str) -> None:
-        self.model_format: str = model_format
-        self.model_info: Optional[ModelInformation] = None
-
-        self._remaining_init_attempts: int = 2
-
-    async def soft_reload(self):
-        self.model_info = None
-
-    def load_model_info_and_init_model(self):
-        """
-        Load model information from disk and initialize the model.
-
-        The detector node uses a lock to make sure that this is not called 
-        concurrently with evaluate() or batch_evaluate(). 
-        """
-        logging.info('Loading model from %s', GLOBALS.data_folder)
-        self.model_info = ModelInformation.load_from_disk(f'{GLOBALS.data_folder}/model')
-        if self.model_info is None:
-            logging.error('No model found')
-            self.model_info = None
-            return
-
-        try:
-            self.init()
-            logging.info('Successfully loaded model %s', self.model_info)
-            self._remaining_init_attempts = 2
-        except Exception as e:
-            self._remaining_init_attempts -= 1
-            logging.error('Could not init model %s. Retries left: %s. Error: %s',
-                          self.model_info, self._remaining_init_attempts, e)
-            self.model_info = None
-            if self._remaining_init_attempts == 0:
-                raise NodeNeedsRestartError('Could not init model') from None
-            raise
-
-    @abstractmethod
-    def init(self):
-        """
-        Initialize the model.
-
-        Called when a (new) model was loaded. 
-        Model information available via `self.model_info`
-        The detector node uses a lock to make sure that this is not called
-        concurrently with evaluate() or batch_evaluate(). 
-        """
+    Subclasses receive the ModelInformation via their constructor (called by the
+    DetectorLogic factory in DetectorNode) and are free to store or ignore it.
+    """
 
     @abstractmethod
     def evaluate(self, image: np.ndarray) -> ImageMetadata:
-        """
-        Evaluate the image and return the detections.
+        """Evaluate the image and return the detections.
 
         Called by the detector node when an image should be evaluated (REST or SocketIO).
         The resulting detections should be stored in the ImageMetadata.
         Tags stored in the ImageMetadata will be uploaded to the learning loop.
-        The function should return empty metadata if the detector is not initialized.
         """
 
     @abstractmethod
     def batch_evaluate(self, images: List[np.ndarray]) -> ImagesMetadata:
-        """
-        Evaluate a batch of images and return the detections.
+        """Evaluate a batch of images and return the detections.
 
         The resulting detections per image should be stored in the ImagesMetadata.
         Tags stored in the ImagesMetadata will be uploaded to the learning loop.
-        The function should return empty metadata if the detector is not initialized.
         """

--- a/learning_loop_node/detector/detector_logic.py
+++ b/learning_loop_node/detector/detector_logic.py
@@ -11,7 +11,8 @@ class DetectorLogicFactory(Protocol):
     The factory controls how the detector is constructed — implementations
     can build synchronously or offload heavy work to a thread pool.
     """
-    model_format: str
+    @property
+    def model_format(self) -> str: ...
 
     async def build(self, model_info: ModelInformation) -> 'DetectorLogic': ...
 

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import gc
 import logging
 import os
 import shutil
@@ -542,6 +543,7 @@ class DetectorNode(Node):
         if self._exclusive_model_build and isinstance(self._detector, _ActiveDetector):
             async with self.detection_lock:  # wait for in-flight detections to finish
                 self._detector = _Updating(version=model_info.version)
+            gc.collect()
 
         try:
             new_detector = await self._detector_factory.build(model_info)

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -196,7 +196,9 @@ class DetectorNode(Node):
     async def on_startup(self) -> None:
         try:
             self.outbox.ensure_continuous_upload()
-            await self._build_and_swap_detector()
+            current_model_dir = self._current_model_symlink()
+            if current_model_dir and os.path.isdir(current_model_dir):
+                await self._build_and_swap_detector(current_model_dir)
         except Exception:
             self.log.exception("error during 'startup'")
         self.operation_mode = OperationMode.Idle
@@ -271,7 +273,7 @@ class DetectorNode(Node):
             """
             Detect objects in a batch of images sent via SocketIO.
 
-            Data dict follows the schema of the detect endpoint, 
+            Data dict follows the schema of the detect endpoint,
             but 'images' is a list of image dicts.
             """
             try:
@@ -428,7 +430,7 @@ class DetectorNode(Node):
     async def _update_model_if_required(self) -> None:
         """Check if a new model is available and update if necessary.
         The Learning Loop will respond with the model info of the deployment target.
-        If version_control is set to FollowLoop or the chosen target model is not used, 
+        If version_control is set to FollowLoop or the chosen target model is not used,
         the detector will update the target_model."""
         try:
             if self.operation_mode != OperationMode.Idle:
@@ -507,17 +509,8 @@ class DetectorNode(Node):
                     self.target_model = None
                     return
 
-            model_symlink = 'model'
             try:
-                os.unlink(model_symlink)
-                os.remove(model_symlink)
-            except Exception:
-                pass
-            os.symlink(target_model_folder, model_symlink)
-            self.log.info('Updated symlink for model to %s', os.readlink(model_symlink))
-
-            try:
-                await self._build_and_swap_detector()
+                await self._build_and_swap_detector(target_model_folder)
             except NodeNeedsRestartError:
                 self.log.error('Node needs restart')
                 sys.exit(0)
@@ -527,17 +520,17 @@ class DetectorNode(Node):
                 self.target_model = None
                 return
 
+            self._update_current_model_symlink(target_model_folder)
             await self._sync_status_with_loop()
-            # self.reload(reason='new model installed')
 
-    async def _build_and_swap_detector(self) -> None:
-        """Load ModelInformation from disk, build a new DetectorLogic via the factory,
+    async def _build_and_swap_detector(self, model_dir: str) -> None:
+        """Load ModelInformation from model_dir, build a new DetectorLogic via the factory,
         then atomically swap self._detector when ready.
         The old detector continues to serve requests until the swap."""
-        logging.info('Loading model from %s', GLOBALS.data_folder)
-        model_info = ModelInformation.load_from_disk(f'{GLOBALS.data_folder}/model')
+        logging.info('Loading model from %s', model_dir)
+        model_info = ModelInformation.load_from_disk(model_dir)
         if model_info is None:
-            logging.info('No model found at %s/model', GLOBALS.data_folder)
+            logging.warning('No model.json found in %s', model_dir)
             return
         try:
             new_detector = await self._detector_factory.build(model_info)
@@ -551,6 +544,22 @@ class DetectorNode(Node):
                 raise NodeNeedsRestartError('Could not build detector') from None
             raise
         self._detector = _ActiveDetector(new_detector, model_info)
+
+    @staticmethod
+    def _current_model_symlink() -> Optional[str]:
+        """Return the absolute path the current_model symlink points to, or None."""
+        link = os.path.join(GLOBALS.data_folder, 'current_model')
+        if os.path.islink(link):
+            return os.path.realpath(link)
+        return None
+
+    @staticmethod
+    def _update_current_model_symlink(model_dir: str) -> None:
+        """Atomically update the current_model symlink to point to model_dir."""
+        link = os.path.join(GLOBALS.data_folder, 'current_model')
+        tmp_link = link + '.tmp'
+        os.symlink(model_dir, tmp_link)
+        os.rename(tmp_link, link)
 
 # ================================== API Implementations ==================================
 

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import gc
 import logging
+import sys
 import os
 import shutil
 import subprocess
@@ -442,8 +443,8 @@ class DetectorNode(Node):
                 return
 
             match self._detector:
-                case _ActiveDetector() as d:
-                    current_version = d.model_info.version
+                case _ActiveDetector(model_info=info):
+                    current_version = info.version
                 case _Updating():
                     self.log.debug('not checking for updates; model update already in progress')
                     return
@@ -541,9 +542,16 @@ class DetectorNode(Node):
             return
 
         if self._exclusive_model_build and isinstance(self._detector, _ActiveDetector):
-            async with self.detection_lock:  # wait for in-flight detections to finish
+            async with self.detection_lock:
+                old_logic = self._detector.logic
                 self._detector = _Updating(version=model_info.version)
-            gc.collect()
+
+                # Ensure that we actually delete the old DetectorLogic here to
+                # free resources before building a new detector.
+                refcount = sys.getrefcount(old_logic)  # 2 = old_logic local + getrefcount arg
+                assert refcount == 2, f'expected 2 refs to old detector logic, got {refcount}'
+                del old_logic
+                gc.collect()
 
         try:
             new_detector = await self._detector_factory.build(model_info)

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -1,10 +1,11 @@
 import asyncio
 import contextlib
+import logging
 import os
 import shutil
 import subprocess
 import sys
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Dict, List, Literal, Optional
 
@@ -32,7 +33,7 @@ from ..globals import GLOBALS
 from ..helpers import background_tasks, environment_reader, run
 from ..helpers.misc import numpy_image_from_dict
 from ..node import Node
-from .detector_logic import DetectorLogic
+from .detector_logic import DetectorLogic, DetectorLogicFactory
 from .exceptions import NodeNeedsRestartError
 from .inbox_filter.relevance_filter import RelevanceFilter
 from .outbox import Outbox
@@ -45,11 +46,20 @@ from .rest import outbox_mode as rest_outbox_mode
 from .rest import upload as rest_upload
 
 
+@dataclass
+class _ActiveDetector:
+    logic: DetectorLogic
+    model_info: ModelInformation
+
+
 class DetectorNode(Node):
 
-    def __init__(self, name: str, detector: DetectorLogic, uuid: Optional[str] = None, use_backdoor_controls: bool = False) -> None:
+    def __init__(self, name: str, detector_factory: DetectorLogicFactory,
+                 uuid: Optional[str] = None, use_backdoor_controls: bool = False) -> None:
         super().__init__(name, uuid=uuid, node_type='detector', needs_login=False, needs_sio=False)
-        self.detector_logic = detector
+        self._detector_factory = detector_factory
+        self._detector: Optional[_ActiveDetector] = None
+        self._remaining_init_attempts: int = 2
         self.organization = environment_reader.organization()
         self.project = environment_reader.project()
         assert self.organization and self.project, 'Detector node needs an organization and an project'
@@ -95,13 +105,13 @@ class DetectorNode(Node):
         return AboutResponse(
             operation_mode=self.operation_mode.value,
             state=self.status.state,
-            model_info=self.detector_logic.model_info,  # pylint: disable=protected-access
+            model_info=self._detector.model_info if self._detector else None,
             target_model=self.target_model.version if self.target_model else None,
             version_control=self.version_control.value
         )
 
     def get_model_version_response(self) -> ModelVersionResponse:
-        current_version = self.detector_logic.model_info.version if self.detector_logic.model_info is not None else 'None'  # pylint: disable=protected-access
+        current_version = self._detector.model_info.version if self._detector else 'None'
         target_version = self.target_model.version if self.target_model is not None else 'None'
         loop_version = self.loop_deployment_target.version if self.loop_deployment_target is not None else 'None'
 
@@ -183,15 +193,10 @@ class DetectorNode(Node):
         self.socket_connection_broken = True
         await self.on_startup()
 
-        # simulate startup
-        await self.detector_logic.soft_reload()
-        await self._load_model_info_and_init_model()
-        self.operation_mode = OperationMode.Idle
-
     async def on_startup(self) -> None:
         try:
             self.outbox.ensure_continuous_upload()
-            await self._load_model_info_and_init_model()
+            await self._build_and_swap_detector()
         except Exception:
             self.log.exception("error during 'startup'")
         self.operation_mode = OperationMode.Idle
@@ -297,8 +302,8 @@ class DetectorNode(Node):
 
         @self.sio.event
         async def info(sid) -> Dict:
-            if self.detector_logic.model_info is not None:
-                return asdict(self.detector_logic.model_info)
+            if self._detector is not None:
+                return asdict(self._detector.model_info)
             return {"status": "No model loaded"}
 
         @self.sio.event
@@ -350,8 +355,8 @@ class DetectorNode(Node):
                 except Exception as e:
                     self.log.exception('could not parse detections')
                     return {'error': str(e)}
-                if self.detector_logic.model_info is not None:
-                    image_metadata = self.add_category_id_to_detections(self.detector_logic.model_info, image_metadata)
+                if self._detector is not None:
+                    image_metadata = self.add_category_id_to_detections(self._detector.model_info, image_metadata)
             else:
                 image_metadata = ImageMetadata()
 
@@ -393,11 +398,7 @@ class DetectorNode(Node):
     async def _sync_status_with_loop(self) -> None:
         """Sync status of the detector with the Learning Loop."""
 
-        if self.detector_logic.model_info is not None:
-            current_model = self.detector_logic.model_info.version
-        else:
-            current_model = None
-
+        current_model = self._detector.model_info.version if self._detector else None
         target_model_version = self.target_model.version if self.target_model else None
 
         status = DetectorStatus(
@@ -409,7 +410,7 @@ class DetectorNode(Node):
             operation_mode=self.operation_mode,
             current_model=current_model,
             target_model=target_model_version,
-            model_format=self.detector_logic.model_format,
+            model_format=self._detector_factory.model_format,
         )
 
         self.log_status_on_change(status.state, status)
@@ -441,8 +442,7 @@ class DetectorNode(Node):
                 self.log.debug('not running any updates; target model is None')
                 return
 
-            current_version = self.detector_logic.model_info.version \
-                if self.detector_logic.model_info is not None else None
+            current_version = self._detector.model_info.version if self._detector else None
 
             if current_version != self.target_model.version:
                 self.log.info('Updating model from %s to %s',
@@ -499,7 +499,7 @@ class DetectorNode(Node):
                     await self.data_exchanger.download_model(target_model_folder,
                                                              Context(organization=self.organization,
                                                                      project=self.project),
-                                                             target_model.id, self.detector_logic.model_format)
+                                                             target_model.id, self._detector_factory.model_format)
                     self.log.info('Downloaded model %s', target_model.version)
                 except Exception:
                     self.log.exception('Could not download model %s', target_model.version)
@@ -517,12 +517,12 @@ class DetectorNode(Node):
             self.log.info('Updated symlink for model to %s', os.readlink(model_symlink))
 
             try:
-                await self._load_model_info_and_init_model()
+                await self._build_and_swap_detector()
             except NodeNeedsRestartError:
                 self.log.error('Node needs restart')
                 sys.exit(0)
             except Exception:
-                self.log.exception('Could not load model, will retry download on next check')
+                self.log.exception('Could not build detector, will retry download on next check')
                 shutil.rmtree(target_model_folder, ignore_errors=True)
                 self.target_model = None
                 return
@@ -530,9 +530,27 @@ class DetectorNode(Node):
             await self._sync_status_with_loop()
             # self.reload(reason='new model installed')
 
-    async def _load_model_info_and_init_model(self) -> None:
-        async with self.detection_lock:
-            self.detector_logic.load_model_info_and_init_model()
+    async def _build_and_swap_detector(self) -> None:
+        """Load ModelInformation from disk, build a new DetectorLogic via the factory,
+        then atomically swap self._detector when ready.
+        The old detector continues to serve requests until the swap."""
+        logging.info('Loading model from %s', GLOBALS.data_folder)
+        model_info = ModelInformation.load_from_disk(f'{GLOBALS.data_folder}/model')
+        if model_info is None:
+            logging.info('No model found at %s/model', GLOBALS.data_folder)
+            return
+        try:
+            new_detector = await self._detector_factory.build(model_info)
+            logging.info('Successfully built detector for model %s', model_info)
+            self._remaining_init_attempts = 2
+        except Exception as e:
+            self._remaining_init_attempts -= 1
+            logging.error('Could not build detector for model %s. Retries left: %s. Error: %s',
+                          model_info, self._remaining_init_attempts, e)
+            if self._remaining_init_attempts == 0:
+                raise NodeNeedsRestartError('Could not build detector') from None
+            raise
+        self._detector = _ActiveDetector(new_detector, model_info)
 
 # ================================== API Implementations ==================================
 
@@ -560,17 +578,21 @@ class DetectorNode(Node):
                              camera_id: Optional[str] = None,
                              source: Optional[str] = None,
                              autoupload: Literal['filtered', 'all', 'disabled'],
-                             creation_date: Optional[str] = None) -> ImageMetadata:
+                             creation_date: Optional[str] = None) -> Optional[ImageMetadata]:
         """
         Main processing function for the detector node.
 
         Used when an image is received via REST or SocketIO.
-        This function infers the detections from the image, 
+        This function infers the detections from the image,
         cares about uploading to the loop and returns the detections as ImageMetadata object.
+        Returns None if no model is loaded.
         """
+        detector = self._detector
+        if detector is None:
+            return None
 
         async with self.detection_lock:
-            metadata = await run.io_bound(self.detector_logic.evaluate, image)
+            metadata = await run.io_bound(detector.logic.evaluate, image)
 
         metadata.tags.extend(tags)
         metadata.source = source
@@ -598,16 +620,20 @@ class DetectorNode(Node):
                                    camera_id: Optional[str] = None,
                                    source: Optional[str] = None,
                                    autoupload: str = 'filtered',
-                                   creation_date: Optional[str] = None) -> ImagesMetadata:
+                                   creation_date: Optional[str] = None) -> Optional[ImagesMetadata]:
         """
-        Processing function for the detector node when a a batch inference is requested via SocketIO.
+        Processing function for the detector node when a batch inference is requested via SocketIO.
 
-        This function infers the detections from all images, 
+        This function infers the detections from all images,
         cares about uploading to the loop and returns the detections as a list of ImageMetadata.
+        Returns None if no model is loaded.
         """
+        detector = self._detector
+        if detector is None:
+            return None
 
         async with self.detection_lock:
-            all_detections = await run.io_bound(self.detector_logic.batch_evaluate, images)
+            all_detections = await run.io_bound(detector.logic.batch_evaluate, images)
 
         for metadata in all_detections.items:
             metadata.tags.extend(tags)

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -536,7 +536,7 @@ class DetectorNode(Node):
         If EXCLUSIVE_MODEL_BUILD is set and a detector is active, the old detector is torn down
         first (freeing e.g. GPU VRAM) and detections are rejected until the new one is ready."""
         logging.info('Loading model from %s', model_dir)
-        model_info = ModelInformation.load_from_disk(model_dir)
+        model_info = ModelInformation.load_from_disk(os.path.abspath(model_dir))
         if model_info is None:
             logging.warning('No model.json found in %s', model_dir)
             return

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Union
 
 import numpy as np
 
@@ -46,19 +46,14 @@ from .rest import outbox_mode as rest_outbox_mode
 from .rest import upload as rest_upload
 
 
-@dataclass
-class _ActiveDetector:
-    logic: DetectorLogic
-    model_info: ModelInformation
-
-
 class DetectorNode(Node):
 
     def __init__(self, name: str, detector_factory: DetectorLogicFactory,
                  uuid: Optional[str] = None, use_backdoor_controls: bool = False) -> None:
         super().__init__(name, uuid=uuid, node_type='detector', needs_login=False, needs_sio=False)
         self._detector_factory = detector_factory
-        self._detector: Optional[_ActiveDetector] = None
+        self._detector: _DetectorState = _Initializing()
+        self._exclusive_model_build: bool = os.environ.get('EXCLUSIVE_MODEL_BUILD', '0').lower() in ('1', 'true')
         self._remaining_init_attempts: int = 2
         self.organization = environment_reader.organization()
         self.project = environment_reader.project()
@@ -105,13 +100,13 @@ class DetectorNode(Node):
         return AboutResponse(
             operation_mode=self.operation_mode.value,
             state=self.status.state,
-            model_info=self._detector.model_info if self._detector else None,
+            model_info=self._detector.model_info if isinstance(self._detector, _ActiveDetector) else None,
             target_model=self.target_model.version if self.target_model else None,
             version_control=self.version_control.value
         )
 
     def get_model_version_response(self) -> ModelVersionResponse:
-        current_version = self._detector.model_info.version if self._detector else 'None'
+        current_version = self._detector.model_info.version if isinstance(self._detector, _ActiveDetector) else 'None'
         target_version = self.target_model.version if self.target_model is not None else 'None'
         loop_version = self.loop_deployment_target.version if self.loop_deployment_target is not None else 'None'
 
@@ -258,14 +253,11 @@ class DetectorNode(Node):
                     autoupload=data.get('autoupload', 'filtered'),
                     creation_date=data.get('creation_date', None)
                 )
-                if det is None:
-                    return {'error': 'no model loaded'}
-                detection_dict = jsonable_encoder(asdict(det))
-                return detection_dict
+                return jsonable_encoder(asdict(det))
+            except DetectorUnavailableError as e:
+                return {'error': str(e)}
             except Exception as e:
                 self.log.exception('could not detect via socketio')
-                # with open('/tmp/bad_img_from_socket_io.jpg', 'wb') as f:
-                #     f.write(data['image'])
                 return {'error': str(e)}
 
         @self.sio.event
@@ -292,21 +284,22 @@ class DetectorNode(Node):
                     autoupload=data.get('autoupload', 'filtered'),
                     creation_date=data.get('creation_date', None)
                 )
-                if det is None:
-                    return {'error': 'no model loaded'}
-                detection_dict = jsonable_encoder(asdict(det))
-                return detection_dict
+                return jsonable_encoder(asdict(det))
+            except DetectorUnavailableError as e:
+                return {'error': str(e)}
             except Exception as e:
                 self.log.exception('could not detect via socketio')
-                # with open('/tmp/bad_img_from_socket_io.jpg', 'wb') as f:
-                #     f.write(data['image'])
                 return {'error': str(e)}
 
         @self.sio.event
         async def info(sid) -> Dict:
-            if self._detector is not None:
-                return asdict(self._detector.model_info)
-            return {"status": "No model loaded"}
+            match self._detector:
+                case _ActiveDetector() as d:
+                    return asdict(d.model_info)
+                case _Updating() as u:
+                    return {"status": f"Updating model to version {u.version}"}
+                case _Initializing():
+                    return {"status": "No model loaded"}
 
         @self.sio.event
         async def about(sid) -> Dict:
@@ -357,8 +350,11 @@ class DetectorNode(Node):
                 except Exception as e:
                     self.log.exception('could not parse detections')
                     return {'error': str(e)}
-                if self._detector is not None:
-                    image_metadata = self.add_category_id_to_detections(self._detector.model_info, image_metadata)
+                try:
+                    detector = unwrap_detector(self._detector)
+                    image_metadata = self.add_category_id_to_detections(detector.model_info, image_metadata)
+                except DetectorUnavailableError as e:
+                    self.log.warning('Cannot add category IDs: %s', e)
             else:
                 image_metadata = ImageMetadata()
 
@@ -400,7 +396,7 @@ class DetectorNode(Node):
     async def _sync_status_with_loop(self) -> None:
         """Sync status of the detector with the Learning Loop."""
 
-        current_model = self._detector.model_info.version if self._detector else None
+        current_model = self._detector.model_info.version if isinstance(self._detector, _ActiveDetector) else None
         target_model_version = self.target_model.version if self.target_model else None
 
         status = DetectorStatus(
@@ -444,7 +440,14 @@ class DetectorNode(Node):
                 self.log.debug('not running any updates; target model is None')
                 return
 
-            current_version = self._detector.model_info.version if self._detector else None
+            match self._detector:
+                case _ActiveDetector() as d:
+                    current_version = d.model_info.version
+                case _Updating():
+                    self.log.debug('not checking for updates; model update already in progress')
+                    return
+                case _Initializing():
+                    current_version = None
 
             if current_version != self.target_model.version:
                 self.log.info('Updating model from %s to %s',
@@ -526,12 +529,20 @@ class DetectorNode(Node):
     async def _build_and_swap_detector(self, model_dir: str) -> None:
         """Load ModelInformation from model_dir, build a new DetectorLogic via the factory,
         then atomically swap self._detector when ready.
-        The old detector continues to serve requests until the swap."""
+        The old detector continues to serve requests until the swap.
+
+        If EXCLUSIVE_MODEL_BUILD is set and a detector is active, the old detector is torn down
+        first (freeing e.g. GPU VRAM) and detections are rejected until the new one is ready."""
         logging.info('Loading model from %s', model_dir)
         model_info = ModelInformation.load_from_disk(model_dir)
         if model_info is None:
             logging.warning('No model.json found in %s', model_dir)
             return
+
+        if self._exclusive_model_build and isinstance(self._detector, _ActiveDetector):
+            async with self.detection_lock:  # wait for in-flight detections to finish
+                self._detector = _Updating(version=model_info.version)
+
         try:
             new_detector = await self._detector_factory.build(model_info)
             logging.info('Successfully built detector for model %s', model_info)
@@ -540,6 +551,8 @@ class DetectorNode(Node):
             self._remaining_init_attempts -= 1
             logging.error('Could not build detector for model %s. Retries left: %s. Error: %s',
                           model_info, self._remaining_init_attempts, e)
+            if not isinstance(self._detector, _ActiveDetector):
+                self._detector = _Initializing()  # no model to fall back to
             if self._remaining_init_attempts == 0:
                 raise NodeNeedsRestartError('Could not build detector') from None
             raise
@@ -587,7 +600,7 @@ class DetectorNode(Node):
                              camera_id: Optional[str] = None,
                              source: Optional[str] = None,
                              autoupload: Literal['filtered', 'all', 'disabled'],
-                             creation_date: Optional[str] = None) -> Optional[ImageMetadata]:
+                             creation_date: Optional[str] = None) -> ImageMetadata:
         """
         Main processing function for the detector node.
 
@@ -596,11 +609,8 @@ class DetectorNode(Node):
         cares about uploading to the loop and returns the detections as ImageMetadata object.
         Returns None if no model is loaded.
         """
-        detector = self._detector
-        if detector is None:
-            return None
-
         async with self.detection_lock:
+            detector = unwrap_detector(self._detector)
             metadata = await run.io_bound(detector.logic.evaluate, image)
 
         metadata.tags.extend(tags)
@@ -629,7 +639,7 @@ class DetectorNode(Node):
                                    camera_id: Optional[str] = None,
                                    source: Optional[str] = None,
                                    autoupload: str = 'filtered',
-                                   creation_date: Optional[str] = None) -> Optional[ImagesMetadata]:
+                                   creation_date: Optional[str] = None) -> ImagesMetadata:
         """
         Processing function for the detector node when a batch inference is requested via SocketIO.
 
@@ -637,11 +647,8 @@ class DetectorNode(Node):
         cares about uploading to the loop and returns the detections as a list of ImageMetadata.
         Returns None if no model is loaded.
         """
-        detector = self._detector
-        if detector is None:
-            return None
-
         async with self.detection_lock:
+            detector = unwrap_detector(self._detector)
             all_detections = await run.io_bound(detector.logic.batch_evaluate, images)
 
         for metadata in all_detections.items:
@@ -713,6 +720,40 @@ class DetectorNode(Node):
 
     def register_sio_events(self, sio_client: AsyncClient):
         pass
+
+
+class _Initializing:
+    """No model ready yet — first build pending or in progress."""
+
+
+@dataclass
+class _Updating:
+    """Exclusive model replacement in progress — detections rejected."""
+    version: str
+
+
+@dataclass
+class _ActiveDetector:
+    logic: DetectorLogic
+    model_info: ModelInformation
+
+
+_DetectorState = Union[_Initializing, _Updating, _ActiveDetector]
+
+
+class DetectorUnavailableError(Exception):
+    pass
+
+
+def unwrap_detector(state: '_DetectorState') -> _ActiveDetector:
+    """Return the active detector or raise DetectorUnavailableError."""
+    match state:
+        case _ActiveDetector() as d:
+            return d
+        case _Updating() as u:
+            raise DetectorUnavailableError(f'updating model to version {u.version}')
+        case _Initializing():
+            raise DetectorUnavailableError('detector not yet initialized')
 
 
 @contextlib.contextmanager

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -191,7 +191,7 @@ class DetectorNode(Node):
     async def on_startup(self) -> None:
         try:
             self.outbox.ensure_continuous_upload()
-            current_model_dir = self._current_model_symlink()
+            current_model_dir = self._current_model_path()
             if current_model_dir and os.path.isdir(current_model_dir):
                 await self._build_and_swap_detector(current_model_dir)
         except Exception:
@@ -568,7 +568,7 @@ class DetectorNode(Node):
         self._detector = _ActiveDetector(new_detector, model_info)
 
     @staticmethod
-    def _current_model_symlink() -> Optional[str]:
+    def _current_model_path() -> Optional[str]:
         """Return the absolute path the current_model symlink points to, or None."""
         link = os.path.join(GLOBALS.data_folder, 'current_model')
         if os.path.islink(link):

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -532,7 +532,8 @@ class DetectorNode(Node):
         The old detector continues to serve requests until the swap.
 
         If EXCLUSIVE_MODEL_BUILD is set and a detector is active, the old detector is torn down
-        first (freeing e.g. GPU VRAM) and detections are rejected until the new one is ready."""
+        first (freeing e.g. GPU VRAM) and detections are rejected until the new one is ready.
+        """
         logging.info('Loading model from %s', model_dir)
         model_info = ModelInformation.load_from_disk(os.path.abspath(model_dir))
         if model_info is None:

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -294,8 +294,8 @@ class DetectorNode(Node):
         @self.sio.event
         async def info(sid) -> Dict:
             match self._detector:
-                case _ActiveDetector() as d:
-                    return asdict(d.model_info)
+                case _ActiveDetector(model_info=info):
+                    return asdict(info)
                 case _Updating() as u:
                     return {"status": f"Updating model to version {u.version}"}
                 case _Initializing():

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -2,7 +2,6 @@ import asyncio
 import contextlib
 import gc
 import logging
-import sys
 import os
 import shutil
 import subprocess
@@ -12,7 +11,6 @@ from datetime import datetime
 from typing import Dict, List, Literal, Optional, Union
 
 import numpy as np
-
 import socketio
 from dacite import from_dict
 from fastapi.encoders import jsonable_encoder

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -351,7 +351,7 @@ class DetectorNode(Node):
                     self.log.exception('could not parse detections')
                     return {'error': str(e)}
                 try:
-                    detector = unwrap_detector(self._detector)
+                    detector = _unwrap_detector(self._detector)
                     image_metadata = self.add_category_id_to_detections(detector.model_info, image_metadata)
                 except DetectorUnavailableError as e:
                     self.log.warning('Cannot add category IDs: %s', e)
@@ -616,10 +616,10 @@ class DetectorNode(Node):
         Used when an image is received via REST or SocketIO.
         This function infers the detections from the image,
         cares about uploading to the loop and returns the detections as ImageMetadata object.
-        Returns None if no model is loaded.
+        Raises exception if no model is loaded.
         """
         async with self.detection_lock:
-            detector = unwrap_detector(self._detector)
+            detector = _unwrap_detector(self._detector)
             metadata = await run.io_bound(detector.logic.evaluate, image)
 
         metadata.tags.extend(tags)
@@ -654,10 +654,10 @@ class DetectorNode(Node):
 
         This function infers the detections from all images,
         cares about uploading to the loop and returns the detections as a list of ImageMetadata.
-        Returns None if no model is loaded.
+        Raises exception if no model is loaded.
         """
         async with self.detection_lock:
-            detector = unwrap_detector(self._detector)
+            detector = _unwrap_detector(self._detector)
             all_detections = await run.io_bound(detector.logic.batch_evaluate, images)
 
         for metadata in all_detections.items:
@@ -754,7 +754,7 @@ class DetectorUnavailableError(Exception):
     pass
 
 
-def unwrap_detector(state: '_DetectorState') -> _ActiveDetector:
+def _unwrap_detector(state: '_DetectorState') -> _ActiveDetector:
     """Return the active detector or raise DetectorUnavailableError."""
     match state:
         case _ActiveDetector() as d:

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -538,7 +538,7 @@ class DetectorNode(Node):
         model_info = ModelInformation.load_from_disk(os.path.abspath(model_dir))
         if model_info is None:
             logging.warning('No model.json found in %s', model_dir)
-            return
+            raise Exception('model.json not found')
 
         if self._exclusive_model_build and isinstance(self._detector, _ActiveDetector):
             async with self.detection_lock:

--- a/learning_loop_node/tests/detector/conftest.py
+++ b/learning_loop_node/tests/detector/conftest.py
@@ -16,7 +16,7 @@ import pytest
 import socketio
 import uvicorn
 
-from learning_loop_node.data_classes import BoxDetection, ImageMetadata, ModelInformation
+from learning_loop_node.data_classes import BoxDetection, ImageMetadata, ImagesMetadata, ModelInformation
 from learning_loop_node.detector.detector_logic import DetectorLogic
 
 from ...detector.detector_node import DetectorNode
@@ -142,7 +142,7 @@ def get_outbox_files(outbox: Outbox):
     return [file for file in files if os.path.isfile(file)]
 
 
-class MockDetectorLogic(DetectorLogic):  # pylint: disable=abstract-method
+class MockDetectorLogic(DetectorLogic):
 
     def __init__(self, model_info: ModelInformation):
         self.image_metadata = ImageMetadata(
@@ -154,6 +154,9 @@ class MockDetectorLogic(DetectorLogic):  # pylint: disable=abstract-method
 
     def evaluate(self, image: np.ndarray) -> ImageMetadata:
         return self.image_metadata
+
+    def batch_evaluate(self, images: list[np.ndarray]) -> ImagesMetadata:
+        raise NotImplementedError()
 
 
 class MockDetectorFactory:

--- a/learning_loop_node/tests/detector/conftest.py
+++ b/learning_loop_node/tests/detector/conftest.py
@@ -33,15 +33,13 @@ detector_port = GLOBALS.detector_port
 
 @contextlib.contextmanager
 def dummy_model_on_disk():
-    """Write a minimal model.json mirroring production layout: models/<version>/ + model symlink."""
-    model_info = ModelInformation(id='test', host='', organization='zauberzeug', project='demo', version='1.0')
-    version_path = os.path.join(GLOBALS.data_folder, 'models', model_info.version)
-    os.makedirs(version_path, exist_ok=True)
-    with open(os.path.join(version_path, 'model.json'), 'w') as f:
+    """Write a minimal model.json into a temporary model directory. Yields the directory path."""
+    model_info = ModelInformation(id='test', host='', organization='zauberzeug', project='demo', version='0.0')
+    model_dir = os.path.join(GLOBALS.data_folder, 'models', model_info.version)
+    os.makedirs(model_dir, exist_ok=True)
+    with open(os.path.join(model_dir, 'model.json'), 'w') as f:
         json.dump(asdict(model_info), f)
-    symlink_path = os.path.join(GLOBALS.data_folder, 'model')
-    os.symlink(version_path, symlink_path)
-    yield
+    yield model_dir
 
 
 def should_have_segmentations(request) -> bool:
@@ -69,9 +67,10 @@ async def test_detector_node():
     os.environ['LOOP_ORGANIZATION'] = 'zauberzeug'
     os.environ['LOOP_PROJECT'] = 'demo'
 
-    with dummy_model_on_disk():
+    with dummy_model_on_disk() as model_dir:
+        os.symlink(model_dir, os.path.join(GLOBALS.data_folder, 'current_model'))  # for subprocess on_startup
         node = DetectorNode(name='test', detector_factory=TestingDetectorFactory())
-        await node._build_and_swap_detector()
+        await node._build_and_swap_detector(model_dir)  # for parent-side direct calls
     await port_is(free=True)
 
     multiprocessing.set_start_method('fork', force=True)
@@ -168,9 +167,9 @@ class MockDetectorFactory:
 async def detector_node():
     os.environ['LOOP_ORGANIZATION'] = 'zauberzeug'
     os.environ['LOOP_PROJECT'] = 'demo'
-    with dummy_model_on_disk():
+    with dummy_model_on_disk() as model_dir:
         node = DetectorNode(name="test_node", detector_factory=MockDetectorFactory())
-        await node._build_and_swap_detector()
+        await node._build_and_swap_detector(model_dir)
     return node
 
 # ====================================== REDUNDANT FIXTURES IN ALL CONFTESTS ! ======================================

--- a/learning_loop_node/tests/detector/conftest.py
+++ b/learning_loop_node/tests/detector/conftest.py
@@ -1,9 +1,12 @@
 import asyncio
+import contextlib
+import json
 import logging
 import multiprocessing
 import os
 import shutil
 import socket
+from dataclasses import asdict
 from glob import glob
 from multiprocessing import Process, log_to_stderr
 from typing import AsyncGenerator
@@ -13,13 +16,13 @@ import pytest
 import socketio
 import uvicorn
 
-from learning_loop_node.data_classes import BoxDetection, ImageMetadata
+from learning_loop_node.data_classes import BoxDetection, ImageMetadata, ModelInformation
 from learning_loop_node.detector.detector_logic import DetectorLogic
 
 from ...detector.detector_node import DetectorNode
 from ...detector.outbox import Outbox
 from ...globals import GLOBALS
-from .testing_detector import TestingDetectorLogic
+from .testing_detector import TestingDetectorFactory
 
 logging.basicConfig(level=logging.INFO)
 
@@ -27,6 +30,18 @@ logging.basicConfig(level=logging.INFO)
 log_to_stderr(logging.INFO)
 
 detector_port = GLOBALS.detector_port
+
+@contextlib.contextmanager
+def dummy_model_on_disk():
+    """Write a minimal model.json mirroring production layout: models/<version>/ + model symlink."""
+    model_info = ModelInformation(id='test', host='', organization='zauberzeug', project='demo', version='1.0')
+    version_path = os.path.join(GLOBALS.data_folder, 'models', model_info.version)
+    os.makedirs(version_path, exist_ok=True)
+    with open(os.path.join(version_path, 'model.json'), 'w') as f:
+        json.dump(asdict(model_info), f)
+    symlink_path = os.path.join(GLOBALS.data_folder, 'model')
+    os.symlink(version_path, symlink_path)
+    yield
 
 
 def should_have_segmentations(request) -> bool:
@@ -54,8 +69,9 @@ async def test_detector_node():
     os.environ['LOOP_ORGANIZATION'] = 'zauberzeug'
     os.environ['LOOP_PROJECT'] = 'demo'
 
-    detector = TestingDetectorLogic()
-    node = DetectorNode(name='test', detector=detector)
+    with dummy_model_on_disk():
+        node = DetectorNode(name='test', detector_factory=TestingDetectorFactory())
+        await node._build_and_swap_detector()
     await port_is(free=True)
 
     multiprocessing.set_start_method('fork', force=True)
@@ -128,8 +144,8 @@ def get_outbox_files(outbox: Outbox):
 
 
 class MockDetectorLogic(DetectorLogic):  # pylint: disable=abstract-method
-    def __init__(self):
-        super().__init__('mock')
+
+    def __init__(self, model_info: ModelInformation):
         self.image_metadata = ImageMetadata(
             box_detections=[BoxDetection(category_name="test",
                                          category_id="1",
@@ -141,11 +157,21 @@ class MockDetectorLogic(DetectorLogic):  # pylint: disable=abstract-method
         return self.image_metadata
 
 
+class MockDetectorFactory:
+    model_format = 'mock'
+
+    async def build(self, model_info: ModelInformation) -> MockDetectorLogic:
+        return MockDetectorLogic(model_info)
+
+
 @pytest.fixture
-def detector_node():
-    os.environ['LOOP_ORGANIZATION'] = 'test_organization'
-    os.environ['LOOP_PROJECT'] = 'test_project'
-    return DetectorNode(name="test_node", detector=MockDetectorLogic())
+async def detector_node():
+    os.environ['LOOP_ORGANIZATION'] = 'zauberzeug'
+    os.environ['LOOP_PROJECT'] = 'demo'
+    with dummy_model_on_disk():
+        node = DetectorNode(name="test_node", detector_factory=MockDetectorFactory())
+        await node._build_and_swap_detector()
+    return node
 
 # ====================================== REDUNDANT FIXTURES IN ALL CONFTESTS ! ======================================
 

--- a/learning_loop_node/tests/detector/conftest.py
+++ b/learning_loop_node/tests/detector/conftest.py
@@ -9,7 +9,7 @@ import socket
 from dataclasses import asdict
 from glob import glob
 from multiprocessing import Process, log_to_stderr
-from typing import AsyncGenerator
+from typing import AsyncGenerator, final
 
 import numpy as np
 import pytest
@@ -30,6 +30,7 @@ logging.basicConfig(level=logging.INFO)
 log_to_stderr(logging.INFO)
 
 detector_port = GLOBALS.detector_port
+
 
 @contextlib.contextmanager
 def dummy_model_on_disk():
@@ -142,6 +143,7 @@ def get_outbox_files(outbox: Outbox):
     return [file for file in files if os.path.isfile(file)]
 
 
+@final
 class MockDetectorLogic(DetectorLogic):
 
     def __init__(self, model_info: ModelInformation):
@@ -159,6 +161,7 @@ class MockDetectorLogic(DetectorLogic):
         raise NotImplementedError()
 
 
+@final
 class MockDetectorFactory:
     model_format = 'mock'
 

--- a/learning_loop_node/tests/detector/test_client_communication.py
+++ b/learning_loop_node/tests/detector/test_client_communication.py
@@ -8,7 +8,7 @@ import requests  # type: ignore
 from PIL import Image
 
 from ...data_classes import ModelInformation
-from ...detector.detector_node import DetectorNode
+from ...detector.detector_node import DetectorNode, _ActiveDetector
 from ...globals import GLOBALS
 from .conftest import get_outbox_files
 from .testing_detector import TestingDetectorLogic
@@ -20,6 +20,7 @@ test_image_path = os.path.join(os.path.dirname(file_path), 'test.jpg')
 @pytest.mark.asyncio
 async def test_detector_path(test_detector_node: DetectorNode):
     assert test_detector_node.outbox.path.startswith('/tmp')
+    assert isinstance(test_detector_node._detector, _ActiveDetector)  # pylint: disable=protected-access
     assert isinstance(test_detector_node._detector.logic, TestingDetectorLogic)  # pylint: disable=protected-access
 
 # pylint: disable=unused-argument

--- a/learning_loop_node/tests/detector/test_client_communication.py
+++ b/learning_loop_node/tests/detector/test_client_communication.py
@@ -20,6 +20,7 @@ test_image_path = os.path.join(os.path.dirname(file_path), 'test.jpg')
 @pytest.mark.asyncio
 async def test_detector_path(test_detector_node: DetectorNode):
     assert test_detector_node.outbox.path.startswith('/tmp')
+    assert isinstance(test_detector_node._detector.logic, TestingDetectorLogic)  # pylint: disable=protected-access
 
 # pylint: disable=unused-argument
 
@@ -51,7 +52,6 @@ def test_rest_detect(test_detector_node: DetectorNode, grouping_key: str):
     image = {('file', open(test_image_path, 'rb'))}
     headers = {grouping_key: '0:0:0:0', 'tags':  'some_tag'}
 
-    assert isinstance(test_detector_node.detector_logic, TestingDetectorLogic)
     response = requests.post(f'http://localhost:{GLOBALS.detector_port}/detect',
                              files=image, headers=headers, timeout=30)
     assert response.status_code == 200

--- a/learning_loop_node/tests/detector/test_detector_node.py
+++ b/learning_loop_node/tests/detector/test_detector_node.py
@@ -47,7 +47,7 @@ async def test_get_detections(detector_node: DetectorNode, monkeypatch):
 
     expected_save_args = {
         'image': np_image,
-        'detections': detector_node.detector_logic.image_metadata,  # type: ignore
+        'detections': detector_node._detector.logic.image_metadata,  # type: ignore
     }
 
     for autoupload, expect_filtered, expect_all in test_cases:

--- a/learning_loop_node/tests/detector/test_relevance_filter.py
+++ b/learning_loop_node/tests/detector/test_relevance_filter.py
@@ -6,7 +6,7 @@ import pytest
 from PIL import Image
 
 from ...data_classes import BoxDetection, ImageMetadata, PointDetection
-from ...detector.detector_node import DetectorNode
+from ...detector.detector_node import DetectorNode, _ActiveDetector
 from .conftest import get_outbox_files
 from .testing_detector import TestingDetectorLogic
 
@@ -19,6 +19,7 @@ async def test_filter_is_used_by_node(test_detector_node: DetectorNode, autouplo
     """Test if filtering is used by the node. In particular, when upload is filtered, the identical detections should not be uploaded twice.
     Note thatt we have to mock the dummy detections to only return a point and a box detection."""
 
+    assert isinstance(test_detector_node._detector, _ActiveDetector)  # pylint: disable=protected-access
     assert isinstance(test_detector_node._detector.logic, TestingDetectorLogic)  # pylint: disable=protected-access
     test_detector_node._detector.logic.det_to_return = ImageMetadata(  # pylint: disable=protected-access
         box_detections=[

--- a/learning_loop_node/tests/detector/test_relevance_filter.py
+++ b/learning_loop_node/tests/detector/test_relevance_filter.py
@@ -19,8 +19,8 @@ async def test_filter_is_used_by_node(test_detector_node: DetectorNode, autouplo
     """Test if filtering is used by the node. In particular, when upload is filtered, the identical detections should not be uploaded twice.
     Note thatt we have to mock the dummy detections to only return a point and a box detection."""
 
-    assert isinstance(test_detector_node.detector_logic, TestingDetectorLogic)
-    test_detector_node.detector_logic.det_to_return = ImageMetadata(
+    assert isinstance(test_detector_node._detector.logic, TestingDetectorLogic)  # pylint: disable=protected-access
+    test_detector_node._detector.logic.det_to_return = ImageMetadata(  # pylint: disable=protected-access
         box_detections=[
             BoxDetection(category_name='some_category_name', x=1, y=2, height=3, width=4,
                          model_name='some_model', confidence=.42, category_id='some_id')],

--- a/learning_loop_node/tests/detector/testing_detector.py
+++ b/learning_loop_node/tests/detector/testing_detector.py
@@ -3,7 +3,7 @@ from typing import List
 
 import numpy as np
 
-from learning_loop_node.data_classes import ImagesMetadata
+from learning_loop_node.data_classes import ImagesMetadata, ModelInformation
 
 from ...data_classes import ImageMetadata
 from ...detector.detector_logic import DetectorLogic
@@ -13,12 +13,8 @@ from ..test_helper import get_dummy_metadata
 class TestingDetectorLogic(DetectorLogic):
     __test__ = False
 
-    def __init__(self) -> None:
-        super().__init__('mocked')
+    def __init__(self, model_info: ModelInformation) -> None:
         self.det_to_return: ImageMetadata = get_dummy_metadata()
-
-    def init(self) -> None:
-        pass
 
     def evaluate(self, image: np.ndarray) -> ImageMetadata:
         logging.info('evaluating')
@@ -26,3 +22,11 @@ class TestingDetectorLogic(DetectorLogic):
 
     def batch_evaluate(self, images: List[np.ndarray]) -> ImagesMetadata:
         raise NotImplementedError()
+
+
+class TestingDetectorFactory:
+    __test__ = False
+    model_format = 'mocked'
+
+    async def build(self, model_info: ModelInformation) -> TestingDetectorLogic:
+        return TestingDetectorLogic(model_info)

--- a/mock_detector/app_code/mock_detector.py
+++ b/mock_detector/app_code/mock_detector.py
@@ -1,5 +1,7 @@
 from typing import List
 
+import numpy as np
+
 from learning_loop_node.data_classes import ImageMetadata, ImagesMetadata, ModelInformation
 from learning_loop_node.detector.detector_logic import DetectorLogic
 
@@ -9,10 +11,10 @@ class MockDetector(DetectorLogic):
     def __init__(self, model_info: ModelInformation) -> None:
         pass
 
-    def evaluate(self, image: bytes) -> ImageMetadata:
+    def evaluate(self, image: np.ndarray) -> ImageMetadata:
         return ImageMetadata()
 
-    def batch_evaluate(self, images: List[bytes]) -> ImagesMetadata:
+    def batch_evaluate(self, images: List[np.ndarray]) -> ImagesMetadata:
         raise NotImplementedError()
 
 

--- a/mock_detector/app_code/mock_detector.py
+++ b/mock_detector/app_code/mock_detector.py
@@ -1,14 +1,12 @@
 from typing import List
 
-from learning_loop_node.data_classes import ImageMetadata, ImagesMetadata
+from learning_loop_node.data_classes import ImageMetadata, ImagesMetadata, ModelInformation
 from learning_loop_node.detector.detector_logic import DetectorLogic
 
 
 class MockDetector(DetectorLogic):
-    def __init__(self, model_format) -> None:
-        super().__init__(model_format=model_format)
 
-    def init(self) -> None:
+    def __init__(self, model_info: ModelInformation) -> None:
         pass
 
     def evaluate(self, image: bytes) -> ImageMetadata:
@@ -16,3 +14,10 @@ class MockDetector(DetectorLogic):
 
     def batch_evaluate(self, images: List[bytes]) -> ImagesMetadata:
         raise NotImplementedError()
+
+
+class MockDetectorFactory:
+    model_format = 'mocked'
+
+    async def build(self, model_info: ModelInformation) -> MockDetector:
+        return MockDetector(model_info)

--- a/mock_detector/app_code/mock_detector.py
+++ b/mock_detector/app_code/mock_detector.py
@@ -1,11 +1,16 @@
-from typing import List
+from typing import final
 
 import numpy as np
 
-from learning_loop_node.data_classes import ImageMetadata, ImagesMetadata, ModelInformation
-from learning_loop_node.detector.detector_logic import DetectorLogic
+from learning_loop_node.data_classes import (
+    ImageMetadata,
+    ImagesMetadata,
+    ModelInformation,
+)
+from learning_loop_node.detector.detector_logic import DetectorLogic, DetectorLogicFactory
 
 
+@final
 class MockDetector(DetectorLogic):
 
     def __init__(self, model_info: ModelInformation) -> None:
@@ -14,12 +19,16 @@ class MockDetector(DetectorLogic):
     def evaluate(self, image: np.ndarray) -> ImageMetadata:
         return ImageMetadata()
 
-    def batch_evaluate(self, images: List[np.ndarray]) -> ImagesMetadata:
+    def batch_evaluate(self, images: list[np.ndarray]) -> ImagesMetadata:
         raise NotImplementedError()
 
 
-class MockDetectorFactory:
-    model_format = 'mocked'
+@final
+class MockDetectorFactory(DetectorLogicFactory):
+
+    @property
+    def model_format(self) -> str:
+        return 'mocked'
 
     async def build(self, model_info: ModelInformation) -> MockDetector:
         return MockDetector(model_info)

--- a/mock_detector/app_code/tests/conftest.py
+++ b/mock_detector/app_code/tests/conftest.py
@@ -1,9 +1,11 @@
 import asyncio
+import json
 import logging
 import multiprocessing
 import os
 import shutil
 import socket
+from dataclasses import asdict
 from multiprocessing import Process
 from typing import AsyncGenerator
 
@@ -15,7 +17,7 @@ from learning_loop_node.data_classes import Category, ModelInformation
 from learning_loop_node.detector.detector_node import DetectorNode
 from learning_loop_node.globals import GLOBALS
 
-from ..mock_detector import MockDetector
+from ..mock_detector import MockDetectorFactory
 
 logging.basicConfig(level=logging.INFO)
 
@@ -54,9 +56,13 @@ async def test_detector_node():
                     Category(id='some_id_2', name='some_category_name_2'),
                     Category(id='some_id_3', name='some_category_name_3')])
 
-    detector = MockDetector(model_format='mocked')
-    node = DetectorNode(name='test', detector=detector)
-    detector.model_info = model_info  # pylint: disable=protected-access
+    version_path = os.path.join(GLOBALS.data_folder, 'models', model_info.version)
+    os.makedirs(version_path, exist_ok=True)
+    with open(os.path.join(version_path, 'model.json'), 'w') as f:
+        json.dump(asdict(model_info), f)
+    os.symlink(version_path, os.path.join(GLOBALS.data_folder, 'model'))
+
+    node = DetectorNode(name='test', detector_factory=MockDetectorFactory())
     await port_is(free=True)
 
     multiprocessing.set_start_method('fork', force=True)

--- a/mock_detector/app_code/tests/conftest.py
+++ b/mock_detector/app_code/tests/conftest.py
@@ -51,16 +51,16 @@ async def test_detector_node():
     os.environ['LOOP_PROJECT'] = 'demo'
 
     model_info = ModelInformation(
-        id='some_uuid', host='some_host', organization='zauberzeug', project='test', version='1',
+        id='some_uuid', host='some_host', organization='zauberzeug', project='test', version='0.0',
         categories=[Category(id='some_id_1', name='some_category_name_1'),
                     Category(id='some_id_2', name='some_category_name_2'),
                     Category(id='some_id_3', name='some_category_name_3')])
 
-    version_path = os.path.join(GLOBALS.data_folder, 'models', model_info.version)
-    os.makedirs(version_path, exist_ok=True)
-    with open(os.path.join(version_path, 'model.json'), 'w') as f:
+    model_dir = os.path.join(GLOBALS.data_folder, 'models', model_info.version)
+    os.makedirs(model_dir, exist_ok=True)
+    with open(os.path.join(model_dir, 'model.json'), 'w') as f:
         json.dump(asdict(model_info), f)
-    os.symlink(version_path, os.path.join(GLOBALS.data_folder, 'model'))
+    os.symlink(model_dir, os.path.join(GLOBALS.data_folder, 'current_model'))
 
     node = DetectorNode(name='test', detector_factory=MockDetectorFactory())
     await port_is(free=True)

--- a/mock_detector/main.py
+++ b/mock_detector/main.py
@@ -1,17 +1,12 @@
 import os
 
-from app_code.mock_detector import MockDetector
+from app_code.mock_detector import MockDetectorFactory
 
 from learning_loop_node import DetectorNode
-from learning_loop_node.data_classes import Category, ModelInformation
 
-model_info = ModelInformation(
-    id='some_uuid', host='some_host', organization='zauberzeug', project='test', version='1',
-    categories=[Category(id='some_id', name='some_category_name')])
-det = MockDetector(model_format='mocked')
 node = DetectorNode(
     name='mocked detector',
-    detector=det,
+    detector_factory=MockDetectorFactory(),
     uuid='85ef1a58-308d-4c80-8931-43d1f752f4f9',
     use_backdoor_controls=True,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ ignore_missing_imports = true
 [tool.ruff]
 indent-width = 4
 line-length = 120
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,44 @@ exclude = ["learning_loop_node.tests*", "learning_loop_node.examples*"]
 
 [tool.mypy]
 ignore_missing_imports = true
+
+
+[tool.ruff]
+indent-width = 4
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "I",   # isort
+    "E",   # pycodestyle
+    "W",   # pycodestyle
+    "B",   # bugbear
+    "F",   # pyflakes
+    "UP",  # pyupgrade
+    "RUF", # ruff
+    "PL",  # pylint
+    "NPY201", # NumPy 2.0
+    "Q",   # flake8-quotes
+]
+fixable = [
+    "I",  # isort
+    "RUF022", # `__all__` is not sorted
+    "Q",  # flake8-quotes
+]
+ignore = [
+    "E501", # line too long
+    "E741",
+    "PLR2004", # magic value comparison
+    "Q001",  # multi line quotes
+    "Q002",  # docstring quotes
+    "PLR0911", # too many
+    "PLR0912", # too many
+    "PLR0913", # too many arguments
+    "PLR0915", # too many arguments
+]
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+multiline-quotes = "single"
+docstring-quotes = "double"
+avoid-escape = true

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,7 @@ wheels = [
 
 [[package]]
 name = "learning-loop-node"
-version = "0.18.0"
+version = "0.18.6"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
DetectorLogic instances are now short(er) lived and only represent a single model version. If a new version is published, a new version is built in the background and replaces the active detector when it's ready. If desired `EXCLUSIVE_MODEL_BUILD=1` can be set to discard the old model before building the new one, thus reducing peak memory usage.

Other changes:
- Add local claude files to .gitignore
- Update uv.lock