### PR TITLE
Introduce TrainerLogicGeneric.abort() and matching socket event

### DIFF
--- a/learning_loop_node/tests/trainer/states/test_state_detecting.py
+++ b/learning_loop_node/tests/trainer/states/test_state_detecting.py
@@ -40,7 +40,7 @@ async def test_detecting_can_be_aborted(test_initialized_trainer: TestingTrainer
     trainer._begin_training_task()
 
     await assert_training_state(trainer.training, TrainerState.Detecting, timeout=5, interval=0.001)
-    await trainer.stop()
+    await trainer.abort()
     await asyncio.sleep(0.1)
 
     assert trainer._training is None

--- a/learning_loop_node/tests/trainer/states/test_state_download_train_model.py
+++ b/learning_loop_node/tests/trainer/states/test_state_download_train_model.py
@@ -2,6 +2,8 @@
 import asyncio
 import os
 
+import pytest
+
 from ....enums import TrainerState
 from ... import test_helper
 from ..state_helper import assert_training_state, create_active_training_file
@@ -36,7 +38,9 @@ async def test_downloading_is_successful(test_initialized_trainer: TestingTraine
     assert os.path.exists(f'{trainer.training.training_folder}/file_2.txt')
 
 
-async def test_abort_download_model(test_initialized_trainer: TestingTrainerLogic):
+@pytest.mark.parametrize('halt_method', ['stop', 'abort'])
+async def test_abort_download_model(test_initialized_trainer: TestingTrainerLogic, halt_method: str):
+    """No model exists yet -> stop() and abort() should produce the same outcome."""
     trainer = test_initialized_trainer
     create_active_training_file(trainer, training_state=TrainerState.DataDownloaded)
     trainer._init_from_last_training()
@@ -44,7 +48,7 @@ async def test_abort_download_model(test_initialized_trainer: TestingTrainerLogi
     trainer._begin_training_task()
     await assert_training_state(trainer.training, TrainerState.TrainModelDownloading, timeout=1, interval=0.001)
 
-    await trainer.stop()
+    await getattr(trainer, halt_method)()
     await asyncio.sleep(0.1)
 
     assert trainer._training is None

--- a/learning_loop_node/tests/trainer/states/test_state_prepare.py
+++ b/learning_loop_node/tests/trainer/states/test_state_prepare.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from ....data_classes import Context
 from ....enums import TrainerState
 from ....trainer.trainer_logic import TrainerLogic
@@ -24,7 +26,11 @@ async def test_preparing_is_successful(test_initialized_trainer: TestingTrainerL
     assert trainer.node.last_training_io.load() == trainer.training
 
 
-async def test_abort_preparing(test_initialized_trainer: TestingTrainerLogic):
+@pytest.mark.parametrize('halt_method', ['stop', 'abort'])
+async def test_abort_preparing(test_initialized_trainer: TestingTrainerLogic, halt_method: str):
+    """In DataDownloading there is no model to save, so stop() and abort()
+    should produce the same outcome (full cleanup). Parametrized to flag any
+    accidental divergence in the future."""
     trainer = test_initialized_trainer
     create_active_training_file(trainer)
     trainer._init_from_last_training()
@@ -32,7 +38,7 @@ async def test_abort_preparing(test_initialized_trainer: TestingTrainerLogic):
     trainer._begin_training_task()
     await assert_training_state(trainer.training, TrainerState.DataDownloading, timeout=1, interval=0.001)
 
-    await trainer.stop()
+    await getattr(trainer, halt_method)()
     await asyncio.sleep(0.1)
 
     assert trainer._training is None  # pylint: disable=protected-access

--- a/learning_loop_node/tests/trainer/states/test_state_train.py
+++ b/learning_loop_node/tests/trainer/states/test_state_train.py
@@ -1,3 +1,5 @@
+from pytest_mock import MockerFixture
+
 from ....enums import TrainerState
 from ...test_helper import condition
 from ..state_helper import assert_training_state, create_active_training_file
@@ -42,6 +44,49 @@ async def test_stop_running_training(test_initialized_trainer: TestingTrainerLog
     await assert_training_state(trainer.training, TrainerState.TrainingFinished, timeout=2, interval=0.01)
 
     assert trainer.node.last_training_io.load() == trainer.training
+
+
+async def test_stop_during_training_uploads_model(mocker: MockerFixture, test_initialized_trainer: TestingTrainerLogic):
+    """stop() during TrainingRunning should let the wind-down states run,
+    so the model ends up uploaded (model_uuid_for_detecting set)."""
+
+    trainer = test_initialized_trainer
+    mocker.patch('learning_loop_node.data_exchanger.DataExchanger.upload_model_get_uuid',
+                 return_value='12345678-bobo-7e92-f95f-424242424242')
+
+    create_active_training_file(trainer, training_state=TrainerState.TrainModelDownloaded)
+    trainer._init_from_last_training()
+    trainer._begin_training_task()
+
+    await condition(lambda: trainer._executor and trainer._executor.is_running(), timeout=1, interval=0.01)
+    await assert_training_state(trainer.training, TrainerState.TrainingRunning, timeout=10, interval=0.01)
+
+    await trainer.stop()
+
+    await condition(lambda: trainer._training is not None
+                    and trainer.training.model_uuid_for_detecting == '12345678-bobo-7e92-f95f-424242424242',
+                    timeout=10, interval=0.05)
+
+
+async def test_abort_during_training(mocker: MockerFixture, test_initialized_trainer: TestingTrainerLogic):
+    """abort() during TrainingRunning skips the wind-down states: no upload call
+    is made, the training is cleared, and the on-disk last_training_io is removed."""
+    trainer = test_initialized_trainer
+    upload_mock = mocker.patch('learning_loop_node.data_exchanger.DataExchanger.upload_model_get_uuid',
+                               return_value='12345678-bobo-7e92-f95f-424242424242')
+
+    create_active_training_file(trainer, training_state=TrainerState.TrainModelDownloaded)
+    trainer._init_from_last_training()
+    trainer._begin_training_task()
+
+    await condition(lambda: trainer._executor and trainer._executor.is_running(), timeout=1, interval=0.01)
+    await assert_training_state(trainer.training, TrainerState.TrainingRunning, timeout=10, interval=0.01)
+
+    await trainer.abort()
+    await condition(lambda: trainer._training is None, timeout=1, interval=0.01)
+
+    upload_mock.assert_not_called()
+    assert trainer.node.last_training_io.exists() is False
 
 
 async def test_training_can_maybe_resumed(test_initialized_trainer: TestingTrainerLogic):

--- a/learning_loop_node/tests/trainer/states/test_state_train.py
+++ b/learning_loop_node/tests/trainer/states/test_state_train.py
@@ -52,7 +52,7 @@ async def test_stop_during_training_uploads_model(mocker: MockerFixture, test_in
 
     trainer = test_initialized_trainer
     mocker.patch('learning_loop_node.data_exchanger.DataExchanger.upload_model_get_uuid',
-                 return_value='12345678-bobo-7e92-f95f-424242424242')
+                 return_value='12345678-abcd-1234-abcd-123456789abc')
 
     create_active_training_file(trainer, training_state=TrainerState.TrainModelDownloaded)
     trainer._init_from_last_training()
@@ -64,7 +64,7 @@ async def test_stop_during_training_uploads_model(mocker: MockerFixture, test_in
     await trainer.stop()
 
     await condition(lambda: trainer._training is not None
-                    and trainer.training.model_uuid_for_detecting == '12345678-bobo-7e92-f95f-424242424242',
+                    and trainer.training.model_uuid_for_detecting == '12345678-abcd-1234-abcd-123456789abc',
                     timeout=10, interval=0.05)
 
 
@@ -73,7 +73,7 @@ async def test_abort_during_training(mocker: MockerFixture, test_initialized_tra
     is made, the training is cleared, and the on-disk last_training_io is removed."""
     trainer = test_initialized_trainer
     upload_mock = mocker.patch('learning_loop_node.data_exchanger.DataExchanger.upload_model_get_uuid',
-                               return_value='12345678-bobo-7e92-f95f-424242424242')
+                               return_value='12345678-abcd-1234-abcd-123456789abc')
 
     create_active_training_file(trainer, training_state=TrainerState.TrainModelDownloaded)
     trainer._init_from_last_training()

--- a/learning_loop_node/tests/trainer/states/test_state_upload_detections.py
+++ b/learning_loop_node/tests/trainer/states/test_state_upload_detections.py
@@ -157,7 +157,7 @@ async def test_abort_uploading(test_initialized_trainer: TestingTrainerLogic):
 
     await assert_training_state(trainer.training, TrainerState.DetectionUploading, timeout=1, interval=0.001)
 
-    await trainer.stop()
+    await trainer.abort()
     await asyncio.sleep(0.1)
 
     assert trainer._training is None

--- a/learning_loop_node/tests/trainer/states/test_state_upload_model.py
+++ b/learning_loop_node/tests/trainer/states/test_state_upload_model.py
@@ -44,7 +44,7 @@ async def test_abort_upload_model(test_initialized_trainer: TestingTrainerLogic)
 
     await assert_training_state(trainer.training, TrainerState.TrainModelUploading, timeout=1, interval=0.001)
 
-    await trainer.stop()
+    await trainer.abort()
     await asyncio.sleep(0.1)
 
     assert trainer._training is None  # pylint: disable=protected-access

--- a/learning_loop_node/trainer/trainer_logic.py
+++ b/learning_loop_node/trainer/trainer_logic.py
@@ -147,20 +147,12 @@ class TrainerLogic(TrainerLogicGeneric):
     async def stop(self) -> None:
         """If executor is running, stop it. Else cancel training task."""
         print('===============> stop received in trainer_logic.', flush=True)
-
         if not self.training_active:
             return
         if self._executor and self._executor.is_running():
             await self.executor.stop_and_wait()
-        elif self.training_task:
-            logging.info('cancelling training task')
-            if self.training_task.cancel():
-                try:
-                    await self.training_task
-                except asyncio.CancelledError:
-                    pass
-                logging.info('cancelled training task')
-                self._may_restart()
+            return
+        await super().stop()
 
     # ---------------------------------------- ABSTRACT METHODS ----------------------------------------
 

--- a/learning_loop_node/trainer/trainer_logic_generic.py
+++ b/learning_loop_node/trainer/trainer_logic_generic.py
@@ -470,23 +470,12 @@ class TrainerLogicGeneric(ABC):
         await self.stop()
 
     async def stop(self):
-        """Stops the training process by canceling training task.
+        """Stop the training. Default is to abort.
         """
-        if not self.training_active:
-            return
-        if self.training_task:
-            logger.info('cancelling training task')
-            if self.training_task.cancel():
-                try:
-                    await self.training_task
-                except asyncio.CancelledError:
-                    pass
-                logger.info('cancelled training task')
-                self._may_restart()
+        await self.abort()
 
     async def abort(self):
-        """Abort the training: jump straight to ``ReadyForCleanup`` without running
-        any wind-down state (no confusion-matrix sync, no model upload, no detection).
+        """Abort the training: cancel the task immediately and discards in-progress model.
         """
         if not self.training_active:
             return

--- a/learning_loop_node/trainer/trainer_logic_generic.py
+++ b/learning_loop_node/trainer/trainer_logic_generic.py
@@ -487,17 +487,9 @@ class TrainerLogicGeneric(ABC):
     async def abort(self):
         """Abort the training: jump straight to ``ReadyForCleanup`` without running
         any wind-down state (no confusion-matrix sync, no model upload, no detection).
-
-        Differs from :meth:`stop` which lets the state machine progress naturally
-        through sync/upload/detect — i.e. ``stop`` = "wind down nicely and keep the
-        model", ``abort`` = "drop everything now". Used by the loop's abort flow so
-        that the model can be discarded safely on the loop side without a race
-        against a late upload.
         """
         if not self.training_active:
             return
-        if self._training is not None:
-            self.training.training_state = TrainerState.ReadyForCleanup
         if self.training_task:
             logger.info('aborting training task')
             if self.training_task.cancel():

--- a/learning_loop_node/trainer/trainer_logic_generic.py
+++ b/learning_loop_node/trainer/trainer_logic_generic.py
@@ -484,6 +484,30 @@ class TrainerLogicGeneric(ABC):
                 logger.info('cancelled training task')
                 self._may_restart()
 
+    async def abort(self):
+        """Abort the training: jump straight to ``ReadyForCleanup`` without running
+        any wind-down state (no confusion-matrix sync, no model upload, no detection).
+
+        Differs from :meth:`stop` which lets the state machine progress naturally
+        through sync/upload/detect — i.e. ``stop`` = "wind down nicely and keep the
+        model", ``abort`` = "drop everything now". Used by the loop's abort flow so
+        that the model can be discarded safely on the loop side without a race
+        against a late upload.
+        """
+        if not self.training_active:
+            return
+        if self._training is not None:
+            self.training.training_state = TrainerState.ReadyForCleanup
+        if self.training_task:
+            logger.info('aborting training task')
+            if self.training_task.cancel():
+                try:
+                    await self.training_task
+                except asyncio.CancelledError:
+                    pass
+                logger.info('aborted training task')
+                self._may_restart()
+
     def _may_restart(self) -> None:
         """If the environment variable RESTART_AFTER_TRAINING is set, the trainer will restart after a training.
         """

--- a/learning_loop_node/trainer/trainer_node.py
+++ b/learning_loop_node/trainer/trainer_node.py
@@ -76,6 +76,15 @@ class TrainerNode(Node):
                 self.log.exception('error in stop_training. Exception:')
             return True
 
+        @sio_client.event
+        async def abort_training():
+            self.log.info('abort_training received. Current state : %s', self.trainer_logic.state)
+            try:
+                await self.trainer_logic.abort()
+            except Exception:
+                self.log.exception('error in abort_training. Exception:')
+            return True
+
     async def send_status(self):
         if not self.sio_client or not self.sio_client.connected:
             self.log.debug('cannot send status - not connected to the Learning Loop')


### PR DESCRIPTION
## Motivation

The Learning Loop's abort flow had no way to tell a trainer to drop everything immediately. Sending `stop_training` let the state machine progress naturally through `ConfusionMatrixSyncing`, `TrainModelUploading`, `Detecting`, and `DetectionUploading` — the right semantic for a graceful stop ("keep the model"), but wrong for an abort ("discard the model"). The loop raced against these late uploads, producing `No training found for trainer …` errors and leaving orphan model files on disk.

## Implementation

- Add `abort_training` SocketIO event handler in `TrainerNode.register_sio_events` that delegates to `TrainerLogicGeneric.abort()`
- Add `TrainerLogicGeneric.abort()` which cancels the running `training_task`; `_perform_state` / `_run` catch the `CancelledError`, set state to `ReadyForCleanup` and run `_clear_training` — the wind-down states are skipped
- Refactor halt semantics so the relationship is explicit:
  - `TrainerLogicGeneric.stop()` now simply delegates to `self.abort()` (one cancel impl, no duplicated body)
  - `TrainerLogic.stop()` overrides with the graceful path (`executor.stop_and_wait`) and falls through to `super().stop()` (= abort) when no executor is running
- Rename the 5 misnamed `test_abort_*` tests to call `trainer.abort()` instead of `trainer.stop()` — they always tested abort semantics, the name was honest, the call wasn't
- Parametrize `test_abort_preparing` and `test_abort_download_model` over `['stop', 'abort']` to flag any accidental divergence in states where the table says both must be equal
- Add new tests in `test_state_train.py` covering the only state where `stop` and `abort` genuinely diverge (TrainingRunning):
  - `test_stop_during_training_uploads_model` — graceful stop -> wind-down runs -> model uploaded
  - `test_abort_during_training` — abort -> wind-down skipped, upload not called, `last_training_io` removed

## Companion PR

Loop side: zauberzeug/loop#346. Without it, the new `abort_training` event is never emitted; older loops keep using `stop_training`, which still works (graceful semantic preserved).

⬛ claude-opus-4-7[1m]