### PR TITLE
Stop the training subprocess on every exit path

### DIFF
--- a/learning_loop_node/tests/trainer/states/test_state_train.py
+++ b/learning_loop_node/tests/trainer/states/test_state_train.py
@@ -89,6 +89,27 @@ async def test_abort_during_training(mocker: MockerFixture, test_initialized_tra
     assert trainer.node.last_training_io.exists() is False
 
 
+async def test_abort_during_training_kills_executor(test_initialized_trainer: TestingTrainerLogic):
+    """abort() must terminate the training subprocess - a CancelledError must not propagate
+    past _train's cleanup and leave the executor process orphaned."""
+    trainer = test_initialized_trainer
+
+    create_active_training_file(trainer, training_state=TrainerState.TrainModelDownloaded)
+    trainer._init_from_last_training()
+    trainer._begin_training_task()
+
+    await condition(lambda: trainer._executor and trainer._executor.is_running(), timeout=1, interval=0.01)
+    await assert_training_state(trainer.training, TrainerState.TrainingRunning, timeout=10, interval=0.01)
+
+    executor = trainer._executor  # keep the reference; _clear_training detaches the training
+    assert executor is not None and executor.is_running()
+
+    await trainer.abort()
+
+    await condition(lambda: not executor.is_running(), timeout=2, interval=0.01)
+    assert not executor.is_running()
+
+
 async def test_training_can_maybe_resumed(test_initialized_trainer: TestingTrainerLogic):
     trainer = test_initialized_trainer
 

--- a/learning_loop_node/trainer/trainer_logic.py
+++ b/learning_loop_node/trainer/trainer_logic.py
@@ -79,9 +79,15 @@ class TrainerLogic(TrainerLogicGeneric):
 
         except TrainingError:
             logging.exception('Exception in trainer_logic._train')
-            await self.executor.stop_and_wait()
             self.training.training_state = previous_state
             raise
+        finally:
+            # Ensure the training subprocess is never left running, regardless of how we leave
+            # this method - in particular on abort(), where a CancelledError would otherwise
+            # propagate past the cleanup and orphan the executor process.
+            # shield so the terminate+wait completes even while the task is being cancelled.
+            if self._executor and self._executor.is_running():
+                await asyncio.shield(self.executor.stop_and_wait())
 
     async def _do_detections(self) -> None:
         context = self.training.context

--- a/learning_loop_node/trainer/trainer_logic.py
+++ b/learning_loop_node/trainer/trainer_logic.py
@@ -82,10 +82,7 @@ class TrainerLogic(TrainerLogicGeneric):
             self.training.training_state = previous_state
             raise
         finally:
-            # Ensure the training subprocess is never left running, regardless of how we leave
-            # this method - in particular on abort(), where a CancelledError would otherwise
-            # propagate past the cleanup and orphan the executor process.
-            # shield so the terminate+wait completes even while the task is being cancelled.
+            # shield so the subprocess is stopped even when the task is cancelled (e.g. on abort())
             if self._executor and self._executor.is_running():
                 await asyncio.shield(self.executor.stop_and_wait())
 


### PR DESCRIPTION
## Motivation

Aborting a training cancels the trainer task, but for executor-based trainers (e.g. classification, yolov5) the `python train.py` subprocess was left running — still holding the GPU. The `CancelledError` from `abort()` propagated past `_train`'s only cleanup (`except TrainingError`), so nothing terminated the executor. This was surfaced by the loop's new `abort_training` flow (zauberzeug/loop#346 + #80): once a node is on 0.20.0 and extends the executor-based `TrainerLogic`, abort orphans the process.

## Implementation

- Move the executor cleanup in `TrainerLogic._train` out of the `except TrainingError` block into a `finally`, so the training subprocess is terminated on **every** exit path (normal return, `TrainingError`, `CancelledError`/abort, and any unexpected exception)
- Use `asyncio.shield(self.executor.stop_and_wait())` so the terminate+wait completes even while the task is being cancelled
- Add `test_abort_during_training_kills_executor`: starts a real training subprocess, aborts mid-run, asserts `executor.is_running()` becomes `False` (no orphan)

## Notes / risks

- `stop()` (graceful) and `abort()` remain distinct: `finally` only guarantees the subprocess is dead; whether `_train` returns normally (→ upload) or with `CancelledError` (→ `ReadyForCleanup`, discard) is unchanged. Covered by the existing `test_stop_during_training_uploads_model` / `test_abort_during_training`.
- The `TrainingError` path is behavior-preserving (executor still killed, `previous_state` still reset) — only the internal ordering changed.
- Relevant train-state tests pass locally. The SocketIO-dependent integration tests could not be run locally (no mock loop running here) and fail identically on the unmodified base; they should be verified in CI.

---
⬛ claude-opus-4-8[1m]