### PR TITLE
Add CONTRIBUTING.md with data team standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,142 @@
+## Data Team Standards
+
+## Linting
+
+We use ruff and [pre-commit](https://github.com/pre-commit/pre-commit) to make sure the coding style is enforced.
+You first need to install pre-commit and the corresponding git commit hooks by running the following commands:
+
+```bash
+python3 -m pip install pre-commit
+pre-commit install
+```
+
+After that you can make sure your code satisfies the coding style by running the following command:
+
+```bash
+pre-commit run --all-files
+```
+
+## Style Guide
+
+### 1. Single or double quotes
+
+We use single quotes for strings in the code and double quotes for docstrings.
+Double quotes may also be used for strings if the string contains a single quote.
+
+### 2. String formatting
+
+We use f-strings if possible (due to their readability).
+Logs shell use the lazy formatting provided by the logging (performance optimization).
+When diverging from above rules, please provide a short comment with `# NOTE: ...` to explaining the reason.
+
+### 3. Line continuation
+
+To break a long statement across multiple lines, we use a trailing backslash (`\`) to break between chained calls, rather than breaking inside a call's parentheses. This reads better for
+fluent/builder chains such as NiceGUI element construction, where the leading `.` on each line clearly marks the continuation and each call keeps its arguments together.
+
+```python
+# preferred
+ui.button('Speichern', on_click=self.save)\
+    .props('no-caps')\
+    .classes('button-primary')
+
+# avoid (using the open parenthesis of a call to wrap)
+ui.button('Speichern', on_click=self.save).props(
+    'no-caps').classes(
+    'button-primary')
+```
+
+## 4. Ordering: Important things first
+
+We want to have main classes and functions at the top of the file, while helper functions and classes should be placed below. This allows to quickly understand the main purpose of the file without having to scroll through a lot of code.
+
+The same rule applies within a class:
+
+- The public interface comes first: the constructor, then the public methods and properties.
+- Every private helper is placed below the methods that call it, so a reader always meets the caller before the callee.
+- If a helper is called by several methods, it is placed below all of them.
+
+```python
+class ReportGenerator:
+
+    def __init__(self, source: Path) -> None:
+        self.source = source
+
+    def generate_summary(self) -> str:
+        rows = self._load_rows()
+        ...
+
+    def generate_details(self) -> str:
+        rows = self._load_rows()
+        ...
+
+    def _load_rows(self) -> list[Row]:
+        """Called by generate_summary and generate_details, so it comes after both."""
+        ...
+```
+
+## 5. Docstrings and type hints
+
+We use the reStructuredText (reST) or Sphinx-style docstring format.
+We don't declare types in the docstring but use type hints.
+While type hints are mandatory, parameter descriptions and docstrings should only
+be used if the function and parameter names are not self-explanatory.
+Examples are listetd below:
+
+### One-line Docstring without parameters
+
+```python
+def greet() -> None:
+    """Print a friendly greeting."""
+    print("Hello!")
+```
+
+### One-line Docstring with parameters
+
+```python
+def square(x: int | float) -> int | float:
+    """Return the square of x.
+
+    :param x: Number to square.
+    :return: The squared value.
+    """
+    return x * x
+```
+
+### Multi-line Docstring without parameters
+
+```python
+def get_timestamp() -> str:
+    """
+    Return the current timestamp as a formatted string.
+
+    This function retrieves the current local time and formats it
+    as "YYYY-MM-DD HH:MM:SS". It can be useful for logging or
+    displaying time information in user interfaces.
+    """
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+```
+
+### Multi-line Docstring with parameters
+
+```python
+def save_data(data: str | bytes, filename: str, overwrite: bool = False) -> None:
+    """
+    Save data to a file.
+
+    This function writes the provided data to a file on disk.
+    If the file already exists and `overwrite` is False, an
+    exception is raised to prevent accidental data loss.
+
+    :param data: The content to be saved. Can be text or bytes.
+    :param filename: Path to the destination file.
+    :param overwrite: Whether to overwrite an existing file.
+    :return: True if the data was saved successfully, False otherwise.
+    :raises FileExistsError: If the file exists and overwrite is False.
+    """
+    if os.path.exists(filename) and not overwrite:
+        raise FileExistsError(f"{filename} already exists.")
+    mode = "wb" if isinstance(data, bytes) else "w"
+    with open(filename, mode) as f:
+        f.write(data)
+```


### PR DESCRIPTION
Adds a CONTRIBUTING.md with the data team standards (`templates/CONTRIBUTING.md` from the [data_team repo](https://github.com/zauberzeug/data_team)); the repo had none so far.

The file starts with the `## Data Team Standards` heading. Everything below it is kept in sync with the template; repo-specific sections can be added above it.

Contents: Linting, Style Guide (1. single or double quotes, 2. string formatting, 3. line continuation), 4. Ordering: important things first (file level and within a class), 5. Docstrings and type hints.