### PR TITLE
Update data team standards in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,33 @@ ui.button('Speichern', on_click=self.save).props(
     'button-primary')
 ```
 
-## 4. Ordering: Important things first
+### 4. Comments
+
+We keep comments as few and as short as possible.
+A comment should only state what is needed to understand the code — not the motivation behind an implementation and not a restatement of what the code already says.
+If the code is clear on its own, it needs no comment.
+
+### 5. Error handling
+
+We do not use return values to signal success or failure.
+A function that returns `True`/`False` or `None` for this purpose forces every caller to remember the convention, and a forgotten check fails silently.
+Instead we raise exceptions — custom exception classes where appropriate — and handle them where the caller can react.
+
+```python
+# preferred
+def parse_config(path: Path) -> Config:
+    if not path.exists():
+        raise ConfigNotFoundError(path)
+    ...
+
+# avoid (None as failure signal)
+def parse_config(path: Path) -> Config | None:
+    if not path.exists():
+        return None
+    ...
+```
+
+## 6. Ordering: Important things first
 
 We want to have main classes and functions at the top of the file, while helper functions and classes should be placed below. This allows to quickly understand the main purpose of the file without having to scroll through a lot of code.
 
@@ -75,7 +101,7 @@ class ReportGenerator:
         ...
 ```
 
-## 5. Docstrings and type hints
+## 7. Docstrings and type hints
 
 We use the reStructuredText (reST) or Sphinx-style docstring format.
 We don't declare types in the docstring but use type hints.


### PR DESCRIPTION
Updates the data team standards block to the latest template state (`templates/CONTRIBUTING.md` in the [data_team repo](https://github.com/zauberzeug/data_team)). Follow-up to #82.

New:

- Rule 4 (Comments): keep comments as few and as short as possible — only what is needed to understand the code, no motivation or restating.
- Rule 5 (Error handling): no `True`/`False`/`None` return values to signal success or failure; raise exceptions (custom classes where appropriate) instead.
- Ordering and Docstrings are renumbered to 6 and 7.