### PR TITLE
Document the /about and /operation_mode detector endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ The endpoint returns None if the upload was successful and an error message othe
 
 For both ways to upload an image, the tag `picked_by_system` is automatically added to the image metadata.
 
+### Node and model information
+
+The detector has a REST endpoint that reports what the node is currently doing and which model it has loaded:
+
+`curl http://localhost/about`
+
+The response contains:
+
+- `operation_mode`: the current operation mode (`startup`, `idle` or `detecting`)
+- `state`: the state of the node (e.g. `idle`, `online`, `detecting`)
+- `model_info`: information about the loaded model (id, organization, project, version, categories, resolution, model size), or `null` if no model is loaded yet
+- `target_model`: the model version the detector is trying to load, or `null` if none is set
+- `version_control`: the model versioning mode (`follow_loop`, `specific_version` or `pause`)
+
+The same information is available via the socketio event `about`:
+`sio.emit('about')`
+
+Use this endpoint if you need the model uuid or its categories. If you only need the version numbers, use `/model_version` (see below).
+
+All REST endpoints of the node are also listed in the automatically generated API documentation at `http://localhost/docs`.
+
 ### Changing the model versioning mode
 
 The detector can be configured to one of the following behaviors:
@@ -130,6 +151,22 @@ The model versioning configuration can also be changed via a socketio event:
 
 There is also a GET endpoint to fetch the current model versioning configuration:
 `sio.emit('get_model_version')` or `curl http://localhost/model_version`
+
+### Changing the operation mode
+
+The operation mode controls whether the detector may load a new model:
+
+- `startup`: used until the first model is loaded
+- `idle`: the detector checks for and performs model updates
+- `detecting`: the detector runs detections and does not load new models
+
+The mode can be read and changed via a REST endpoint. Example Usage:
+
+- Fetch the current operation mode: `curl http://localhost/operation_mode`
+- Allow model updates: `curl -X PUT -d "idle" http://localhost/operation_mode`
+- Block model updates: `curl -X PUT -d "detecting" http://localhost/operation_mode`
+
+The GET request returns the mode as plain text. The PUT request returns status code 422 if the given value is not one of the three modes above.
 
 ### Changing the outbox mode
 

--- a/learning_loop_node/detector/rest/operation_mode.py
+++ b/learning_loop_node/detector/rest/operation_mode.py
@@ -19,7 +19,7 @@ async def put_operation_mode(request: Request):
 
     Example Usage
 
-        curl -X PUT -d "check_for_updates" http://localhost/operation_mode
+        curl -X PUT -d "idle" http://localhost/operation_mode
         curl -X PUT -d "detecting" http://localhost/operation_mode
     '''
 


### PR DESCRIPTION
## What

The detector node has REST endpoints that were missing from the README:

- `GET /about` — operation mode, node state, full model information, target model version, versioning mode
- `GET`/`PUT /operation_mode` — read and set the operation mode

This adds a section for each. The `/about` section lists the response fields and points to `/model_version` for the case where only version numbers are needed. The operation mode section lists the three valid values (`startup`, `idle`, `detecting`) and notes that an invalid value returns 422.

The README also never mentioned the generated API docs at `/docs`, so the `/about` section links there.

## Also fixed

The docstring for `PUT /operation_mode` used `check_for_updates` as an example value. That value no longer exists in `OperationMode`, so copying the example gave a 422. Replaced it with `idle`.

## Notes

Documentation only, no behavior change. Field names and enum values were taken from `AboutResponse`, `ModelInformation`, `OperationMode` and `VersionMode`.