### PR TITLE
Report node version in detector status sync

### DIFF
--- a/learning_loop_node/data_classes/general.py
+++ b/learning_loop_node/data_classes/general.py
@@ -185,3 +185,4 @@ class DetectorStatus():
     target_model: Optional[str]
     errors: Dict
     operation_mode: str
+    node_version: Optional[str] = None

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -49,9 +49,11 @@ from .rest import upload as rest_upload
 class DetectorNode(Node):
 
     def __init__(self, name: str, detector_factory: DetectorLogicFactory,
-                 uuid: Optional[str] = None, use_backdoor_controls: bool = False) -> None:
+                 uuid: Optional[str] = None, use_backdoor_controls: bool = False,
+                 version: Optional[str] = None) -> None:
         super().__init__(name, uuid=uuid, node_type='detector', needs_login=False, needs_sio=False)
         self._detector_factory = detector_factory
+        self.node_version: Optional[str] = version or os.environ.get('NODE_VERSION')
         self._detector: _DetectorState = _Initializing()
         self._exclusive_model_build: bool = os.environ.get('EXCLUSIVE_MODEL_BUILD', '0').lower() in ('1', 'true')
         self._remaining_init_attempts: int = 2
@@ -409,6 +411,7 @@ class DetectorNode(Node):
             current_model=current_model,
             target_model=target_model_version,
             model_format=self._detector_factory.model_format,
+            node_version=self.node_version,
         )
 
         self.log_status_on_change(status.state, status)

--- a/learning_loop_node/detector/detector_node.py
+++ b/learning_loop_node/detector/detector_node.py
@@ -49,11 +49,10 @@ from .rest import upload as rest_upload
 class DetectorNode(Node):
 
     def __init__(self, name: str, detector_factory: DetectorLogicFactory,
-                 uuid: Optional[str] = None, use_backdoor_controls: bool = False,
-                 version: Optional[str] = None) -> None:
+                 uuid: Optional[str] = None, use_backdoor_controls: bool = False) -> None:
         super().__init__(name, uuid=uuid, node_type='detector', needs_login=False, needs_sio=False)
         self._detector_factory = detector_factory
-        self.node_version: Optional[str] = version or os.environ.get('NODE_VERSION')
+        self.node_version: Optional[str] = os.environ.get('NODE_VERSION')
         self._detector: _DetectorState = _Initializing()
         self._exclusive_model_build: bool = os.environ.get('EXCLUSIVE_MODEL_BUILD', '0').lower() in ('1', 'true')
         self._remaining_init_attempts: int = 2


### PR DESCRIPTION
## Motivation

Operators cannot see which software version a deployed detector is running, making it hard to spot outdated nodes in the field. The detector now reports its version to the Learning Loop, where it is shown in the detector overview (loop PR #380).

## Implementation

- Extend `DetectorStatus` with an optional `node_version` field (defaults to `None`, so nodes without a version stay backward compatible)
- Read the version from the `NODE_VERSION` environment variable in `DetectorNode.__init__`; the node repos bake it into their images at build time from the release tag (e.g. dfine_node #30, yolov5_node #52)
- Include `node_version` in the status payload of `_sync_status_with_loop`

The version is deliberately configured via environment only — no constructor parameter — so there is exactly one way to set it across all node repos.

---
⬛ claude-fable-5
