### PR TITLE
Add AGENTS.md and re-sync the shared CONTRIBUTING block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AI Agent Guidelines for the Learning Loop Node Library
+
+`learning_loop_node` is the **public Python library** every node uses to talk to the
+[Learning Loop](https://learning-loop.ai). Four node types build on it: Trainer, Detector,
+Annotator and Converter. It is published to PyPI, so its public surface is an API that
+`loop`, `dfine_node`, `yolov5_node` and `classification_node` depend on.
+
+For coding standards see [CONTRIBUTING.md](CONTRIBUTING.md). [README.md](README.md) documents the
+environment variables, the node types and how to write a node against them.
+
+## Layout
+
+- `learning_loop_node/` — the library itself: `node.py` and `rest.py` for the shared node
+  machinery, `trainer/`, `detector/`, `annotation/` for the per-type base logic, `data_classes/`
+  and `enums/` for the wire types, `loop_communication.py` and `data_exchanger.py` for the
+  loop-facing HTTP and socket.io traffic.
+- `learning_loop_node/tests/` — `annotator`, `detector`, `trainer` and `general` suites.
+- `mock_trainer/`, `mock_detector/`, `mock_annotator/` — reference implementations with their own
+  tests. They are what `loop`'s CI runs against, so they are also the best template for a new node.
+- `demo_segmentation_tool/` — a worked annotator example.
+
+## Running and testing
+
+The suites talk to a real Learning Loop instance and read their credentials from a local `.env`
+(`LOOP_HOST`, `LOOP_USERNAME`, `LOOP_PASSWORD`). Without a reachable loop they cannot pass — do not
+treat their failure as a regression you introduced.
+
+```bash
+./run_tests.sh              # all suites
+./run_tests.sh <filter>     # passed to pytest as -k
+```
+
+There is no `.pre-commit-config.yaml` here and no ruff in the project environment, despite what the
+shared Linting section says. Lint with:
+
+```bash
+uvx ruff check .
+```
+
+A clean tree already reports several hundred ruff findings, so a clean run is not a reachable goal.
+Compare the count on the files you touched, before and after.
+
+`.github/workflows/pytest.yml` runs the suites, `publish.yml` releases to PyPI on a tagged release.
+
+## Working in this repository
+
+- **This is a library — declaring a dependency is part of its API.** Before removing or loosening
+  one, grep the consumers (`../loop`, `../dfine_node`, `../yolov5_node`,
+  `../classification_node`) for the package: a consumer that imports it without declaring it
+  inherits it from here and breaks when it goes away.
+- **Renaming or reshaping anything exported** breaks those four repositories. Say so in the pull
+  request and check whether a companion change is needed there.
+- `../loop` checks this repository out as its `nodes` symlink, so a local change is visible to a
+  local loop immediately — but only a released version reaches CI and production.
+- Bump `version` in `pyproject.toml` for a release; the trainer nodes pin the library version in
+  their image tags (`A.B.C-nlvX.Y.Z`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,43 @@ environment variables, the node types and how to write a node against them.
   tests. They are what `loop`'s CI runs against, so they are also the best template for a new node.
 - `demo_segmentation_tool/` — a worked annotator example.
 
+## Architecture
+
+Every node is a `FastAPI` subclass (`node.py`): its lifespan connects to the loop and starts a
+`repeat_loop` that calls the subclass' `on_repeat` every `repeat_loop_cycle_sec` (5 s) — that loop,
+not an event handler, is what drives status reporting, model updates and training continuation.
+Subclasses implement `on_startup`, `on_shutdown`, `on_repeat` and `register_sio_events`.
+
+Two channels lead to the loop and both are needed: `LoopCommunicator` (httpx, login cookies, retry
+on 401/429) for the REST API, and a socket.io *client* for status updates and loop-issued commands.
+`DataExchanger` sits on top of the communicator and moves images and model zips.
+
+- **Trainer** — `TrainerLogicGeneric._training_loop` is a state machine over `TrainerState`
+  (`enums/trainer.py`): download data → download base model → train → sync confusion matrix →
+  upload model → detect → upload detections → cleanup. `_perform_state` wraps each step: an
+  ordinary exception records the error and rewinds to the previous state (retried on the next
+  cycle), a `CriticalError` jumps to `ReadyForCleanup`. Every transition is persisted through
+  `LastTrainingIO`, so `try_continue_run_if_incomplete` resumes an interrupted training after a
+  restart. The loop starts a training via the `begin_training` sio event. A concrete trainer
+  implements `_train`, `_do_detections`, `_get_new_best_training_state`, `_on_metrics_published`,
+  `_get_latest_model_files` and `_clear_training_data`; `TrainerLogic` adds an `Executor` for
+  trainers that shell out to a training process.
+- **Detector** — the exception to the pattern: constructed with `needs_login=False, needs_sio=False`,
+  so it has no sio client to the loop. It *hosts* a socket.io server for its own clients and polls
+  `/{org}/projects/{project}/deployment/target` over REST in `on_repeat` instead. `_DetectorState`
+  (`_Initializing` / `_Updating` / `_ActiveDetector`) models the model swap: download to
+  `models/<version>`, build a `DetectorLogic` through the factory, then swap atomically so the old
+  model keeps serving until the new one is ready (unless `EXCLUSIVE_MODEL_BUILD` frees VRAM first).
+  `OperationMode` gates whether updates may happen at all. Detections flow through
+  `RelevanceFilter`, which writes selected images to the `Outbox` on disk; a separate upload process
+  drains it.
+- **Annotator** — thin: it forwards the loop frontend's `handle_user_input` events into
+  `AnnotatorLogic` and keeps a per-frontend history.
+
+All node state lives under `GLOBALS.data_folder` (`DATA_FOLDER`, default `/data`): `uuids.json`
+(the node uuid is derived from its name and reused across restarts), `models/` plus the
+`current_model` symlink, `outbox/`, and the per-project training folders.
+
 ## Running and testing
 
 The suites talk to a real Learning Loop instance and read their credentials from a local `.env`
@@ -29,6 +66,21 @@ treat their failure as a regression you introduced.
 ./run_tests.sh              # all suites
 ./run_tests.sh <filter>     # passed to pytest as -k
 ```
+
+Each suite carries its own `pytest.ini` (that is where `asyncio_mode = auto` comes from), so always
+run pytest with a path inside one suite — a bare `pytest` from the repository root picks up no
+config and the async tests error out:
+
+```bash
+python -m pytest learning_loop_node/tests/trainer -v                     # one suite
+python -m pytest learning_loop_node/tests/trainer/test_errors.py -v      # one file
+python -m pytest learning_loop_node/tests/trainer -v -k <test_name>      # one test
+```
+
+An autouse fixture repoints `GLOBALS.data_folder` at `/tmp/learning_loop_lib_data` and wipes it
+around every test, so tests never touch `/data`. The `general` suite generates and deletes a real
+`zauberzeug/pytest_nodelib_general` project on the loop; the detector suite starts the node in a
+forked uvicorn process on `GLOBALS.detector_port`.
 
 There is no `.pre-commit-config.yaml` here and no ruff in the project environment, despite what the
 shared Linting section says. Lint with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 `learning_loop_node` is the **public Python library** every node uses to talk to the
 [Learning Loop](https://learning-loop.ai). Four node types build on it: Trainer, Detector,
-Annotator and Converter. It is published to PyPI, so its public surface is an API that
-`loop`, `dfine_node`, `yolov5_node` and `classification_node` depend on.
+Annotator and Converter. It is published to PyPI, so its public surface is an API that the
+Learning Loop backend and every node repository depends on — `../yolov5_node` is the public one.
 
 For coding standards see [CONTRIBUTING.md](CONTRIBUTING.md). [README.md](README.md) documents the
 environment variables, the node types and how to write a node against them.
@@ -82,8 +82,7 @@ around every test, so tests never touch `/data`. The `general` suite generates a
 `zauberzeug/pytest_nodelib_general` project on the loop; the detector suite starts the node in a
 forked uvicorn process on `GLOBALS.detector_port`.
 
-There is no `.pre-commit-config.yaml` here and no ruff in the project environment, despite what the
-shared Linting section says. Lint with:
+There is no `.pre-commit-config.yaml` here and no ruff in the project environment. Lint with:
 
 ```bash
 uvx ruff check .
@@ -97,11 +96,10 @@ Compare the count on the files you touched, before and after.
 ## Working in this repository
 
 - **This is a library — declaring a dependency is part of its API.** Before removing or loosening
-  one, grep the consumers (`../loop`, `../dfine_node`, `../yolov5_node`,
-  `../classification_node`) for the package: a consumer that imports it without declaring it
-  inherits it from here and breaks when it goes away.
-- **Renaming or reshaping anything exported** breaks those four repositories. Say so in the pull
-  request and check whether a companion change is needed there.
+  one, grep every consuming repository checked out beside this one for the package: a consumer that
+  imports it without declaring it inherits it from here and breaks when it goes away.
+- **Renaming or reshaping anything exported** breaks those repositories. Say so in the pull request
+  and check whether a companion change is needed there.
 - `../loop` checks this repository out as its `nodes` symlink, so a local change is visible to a
   local loop immediately — but only a released version reaches CI and production.
 - Bump `version` in `pyproject.toml` for a release; the trainer nodes pin the library version in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,34 @@
+# Contributing to Learning Loop Node
+
 ## Data Team Standards
 
 ## Linting
 
-We use ruff and [pre-commit](https://github.com/pre-commit/pre-commit) to make sure the coding style is enforced.
-You first need to install pre-commit and the corresponding git commit hooks by running the following commands:
+We use [ruff](https://docs.astral.sh/ruff/) to enforce the coding style.
+Its rules live in the `pyproject.toml` of the respective (sub-)project.
+
+Repositories that ship a `.pre-commit-config.yaml` run ruff through
+[pre-commit](https://github.com/pre-commit/pre-commit).
+Install the git hooks once:
 
 ```bash
 python3 -m pip install pre-commit
 pre-commit install
 ```
 
-After that you can make sure your code satisfies the coding style by running the following command:
+After that you can check the whole repository with:
 
 ```bash
 pre-commit run --all-files
 ```
+
+Repositories without a `.pre-commit-config.yaml` run ruff directly:
+
+```bash
+uvx ruff check .
+```
+
+The repository-specific part of this file names the exact command wherever it differs.
 
 ## Style Guide
 
@@ -26,8 +40,8 @@ Double quotes may also be used for strings if the string contains a single quote
 ### 2. String formatting
 
 We use f-strings if possible (due to their readability).
-Logs shell use the lazy formatting provided by the logging (performance optimization).
-When diverging from above rules, please provide a short comment with `# NOTE: ...` to explaining the reason.
+Logs shall use the lazy formatting provided by logging (performance optimization).
+When diverging from above rules, please provide a short comment with `# NOTE: ...` to explain the reason.
 
 ### 3. Line continuation
 
@@ -72,7 +86,7 @@ def parse_config(path: Path) -> Config | None:
     ...
 ```
 
-## 6. Ordering: Important things first
+### 6. Ordering: Important things first
 
 We want to have main classes and functions at the top of the file, while helper functions and classes should be placed below. This allows to quickly understand the main purpose of the file without having to scroll through a lot of code.
 
@@ -101,23 +115,23 @@ class ReportGenerator:
         ...
 ```
 
-## 7. Docstrings and type hints
+### 7. Docstrings and type hints
 
 We use the reStructuredText (reST) or Sphinx-style docstring format.
 We don't declare types in the docstring but use type hints.
 While type hints are mandatory, parameter descriptions and docstrings should only
 be used if the function and parameter names are not self-explanatory.
-Examples are listetd below:
+Examples are listed below:
 
-### One-line Docstring without parameters
+#### One-line Docstring without parameters
 
 ```python
 def greet() -> None:
     """Print a friendly greeting."""
-    print("Hello!")
+    print('Hello!')
 ```
 
-### One-line Docstring with parameters
+#### One-line Docstring with parameters
 
 ```python
 def square(x: int | float) -> int | float:
@@ -129,7 +143,7 @@ def square(x: int | float) -> int | float:
     return x * x
 ```
 
-### Multi-line Docstring without parameters
+#### Multi-line Docstring without parameters
 
 ```python
 def get_timestamp() -> str:
@@ -140,10 +154,10 @@ def get_timestamp() -> str:
     as "YYYY-MM-DD HH:MM:SS". It can be useful for logging or
     displaying time information in user interfaces.
     """
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 ```
 
-### Multi-line Docstring with parameters
+#### Multi-line Docstring with parameters
 
 ```python
 def save_data(data: str | bytes, filename: str, overwrite: bool = False) -> None:
@@ -157,12 +171,30 @@ def save_data(data: str | bytes, filename: str, overwrite: bool = False) -> None
     :param data: The content to be saved. Can be text or bytes.
     :param filename: Path to the destination file.
     :param overwrite: Whether to overwrite an existing file.
-    :return: True if the data was saved successfully, False otherwise.
     :raises FileExistsError: If the file exists and overwrite is False.
     """
     if os.path.exists(filename) and not overwrite:
-        raise FileExistsError(f"{filename} already exists.")
-    mode = "wb" if isinstance(data, bytes) else "w"
+        raise FileExistsError(f'{filename} already exists.')
+    mode = 'wb' if isinstance(data, bytes) else 'w'
     with open(filename, mode) as f:
         f.write(data)
+```
+
+### 8. Relative imports within a package
+
+Inside a package we import other modules of the same package with relative imports, not with the package name.
+This way the package can be renamed or moved without touching its imports.
+We use the shortest path: siblings with a single dot, no going up and back down (`from ..ui.numpad import ...` in a module that lives in `ui/` itself).
+Code outside the package — scripts, tests — has no choice and uses absolute imports.
+
+```python
+# preferred (in app/ui/scan_view.py)
+from .. import config
+from ..system import System
+from .numpad import Numpad
+
+# avoid
+from app import config
+from app.system import System
+from app.ui.numpad import Numpad
 ```


### PR DESCRIPTION

## Motivation

The team-wide part of `CONTRIBUTING.md` — linting plus the numbered style guide — existed as four
byte-identical copies of `templates/CONTRIBUTING.md` in the `data_team` vault, with no note anywhere
saying where the text came from. `classification_node` had already drifted out of that set. And
without an `AGENTS.md` every agent session has to work out the project structure from scratch.

## Implementation

- Give the file a title and re-sync the block below `## Data Team Standards` with
  `templates/CONTRIBUTING.md` (this repo previously held the bare block with no heading of its own)
- Add `AGENTS.md`: package layout, the mock nodes as the reference implementations, `./run_tests.sh`
  and the fact that the suites need a reachable loop, plus the honest lint situation — there is no
  `.pre-commit-config.yaml` and no ruff in the environment despite what the shared section says, and
  a clean tree already reports several hundred findings
- Spell out that this is a published library, so a dependency declaration is API: consumers that
  import a package without declaring it inherit it from here
- Add `CLAUDE.md` importing it via `@AGENTS.md`
- Add an `Architecture` section: the `repeat_loop` that drives every node, the two channels to the
  loop (`LoopCommunicator` plus the sio client), the trainer state machine and how it resumes after a
  restart, the detector's model-swap states, and the layout under `GLOBALS.data_folder`
- Document the per-suite `pytest.ini` trap — a bare `pytest` from the repository root picks up no
  config and the async tests error out
- Keep the file free of private repository names: `dfine_node` and `classification_node` appear
  nowhere else in this public tree, and the dependency rule they illustrated holds without them

---
⬛ claude-opus-5[1m] (extended thinking)