### PR TITLE
Share the generic parts of a node

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,28 @@ name: Run Tests
 on: [push]
 
 jobs:
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: set up uv
+        uses: astral-sh/setup-uv@v3
+      - name: install dependencies
+        run: |
+          uv sync --extra dev --frozen
+      - name: test_unit
+        # no Learning Loop and no secrets needed, so this suite gates the slow ones
+        run: |
+          uv run python -m pytest learning_loop_node/tests/unit -v
+
   pytest_3_10:
+    needs:
+      - unit
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -91,6 +112,7 @@ jobs:
 
   slack:
     needs:
+      - unit
       - pytest_3_10
       - pytest_3_13
     if: always() # also execute when pytest fails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@ environment variables, the node types and how to write a node against them.
   machinery, `trainer/`, `detector/`, `annotation/` for the per-type base logic, `data_classes/`
   and `enums/` for the wire types, `loop_communication.py` and `data_exchanger.py` for the
   loop-facing HTTP and socket.io traffic.
-- `learning_loop_node/tests/` — `annotator`, `detector`, `trainer` and `general` suites.
+- `learning_loop_node/tests/` — `unit`, `annotator`, `detector`, `trainer` and `general` suites.
+  Only `unit` runs without a Learning Loop; it covers the pure helpers such as
+  `detector/postprocess.py` and `detector/geometry.py`.
 - `mock_trainer/`, `mock_detector/`, `mock_annotator/` — reference implementations with their own
   tests. They are what `loop`'s CI runs against, so they are also the best template for a new node.
 - `demo_segmentation_tool/` — a worked annotator example.
@@ -52,15 +54,30 @@ on 401/429) for the REST API, and a socket.io *client* for status updates and lo
 - **Annotator** — thin: it forwards the loop frontend's `handle_user_input` events into
   `AnnotatorLogic` and keeps a per-frontend history.
 
+`detector/postprocess.py` and `detector/geometry.py` hold the parts of a detector that do *not*
+depend on the model: confidence filtering, per-class NMS, box/point clipping, and turning
+predictions into the loop's dataclasses. A node should import them rather than write its own —
+every node repository had grown its own drifting copy, which is why they live here. Note the two
+containers: `to_image_metadata` builds what a **detector** node reports, `to_detections` what a
+**trainer**'s auto-detection pass reports. Both go through one routine, so the two paths cannot
+drift apart again.
+
 All node state lives under `GLOBALS.data_folder` (`DATA_FOLDER`, default `/data`): `uuids.json`
 (the node uuid is derived from its name and reused across restarts), `models/` plus the
 `current_model` symlink, `outbox/`, and the per-project training folders.
 
 ## Running and testing
 
-The suites talk to a real Learning Loop instance and read their credentials from a local `.env`
-(`LOOP_HOST`, `LOOP_USERNAME`, `LOOP_PASSWORD`). Without a reachable loop they cannot pass — do not
-treat their failure as a regression you introduced.
+The `unit` suite is self-contained — no Learning Loop, no credentials, no network — so it is the
+one to run while iterating, and the one CI gates the others on:
+
+```bash
+python -m pytest learning_loop_node/tests/unit -v
+```
+
+Every other suite talks to a real Learning Loop instance and reads its credentials from a local
+`.env` (`LOOP_HOST`, `LOOP_USERNAME`, `LOOP_PASSWORD`). Without a reachable loop those cannot pass —
+do not treat their failure as a regression you introduced.
 
 ```bash
 ./run_tests.sh              # all suites
@@ -91,7 +108,8 @@ uvx ruff check .
 A clean tree already reports several hundred ruff findings, so a clean run is not a reachable goal.
 Compare the count on the files you touched, before and after.
 
-`.github/workflows/pytest.yml` runs the suites, `publish.yml` releases to PyPI on a tagged release.
+`.github/workflows/pytest.yml` runs the suites (the `unit` job first, without secrets),
+`publish.yml` releases to PyPI on a tagged release.
 
 ## Working in this repository
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,14 @@ on 401/429) for the REST API, and a socket.io *client* for status updates and lo
 - **Annotator** — thin: it forwards the loop frontend's `handle_user_input` events into
   `AnnotatorLogic` and keeps a per-frontend history.
 
+`helpers/entrypoint.py` holds what every node's `main.py` repeats: `node_parser` builds a
+configargparse parser with `--host`/`--port`, `run_node` starts uvicorn. A setting is a flag
+*and* an environment variable from one declaration — `--conf-threshold` reads
+`CONF_THRESHOLD`. The exception is `--host`/`--port`, which read `NODE_HOST`/`NODE_PORT`: the
+bare `HOST` already means the loop's address, and a node adopting it would hand it to uvicorn
+and fail to bind. A node that used to require a prefix passes `legacy_env_prefix`, and the
+prefixed names keep working with a warning.
+
 `detector/postprocess.py` and `detector/geometry.py` hold the parts of a detector that do *not*
 depend on the model: confidence filtering, per-class NMS, box/point clipping, and turning
 predictions into the loop's dataclasses. A node should import them rather than write its own —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@ on 401/429) for the REST API, and a socket.io *client* for status updates and lo
 - **Annotator** — thin: it forwards the loop frontend's `handle_user_input` events into
   `AnnotatorLogic` and keeps a per-frontend history.
 
+`trainer/subprocess.py`, `trainer/batch_size.py` and `trainer/metrics.py` hold the parts of a
+trainer that are not framework-specific. `iterator_cpu_bound` runs a training generator in a
+spawned process and yields its progress through a `maxsize=1` queue, so the event loop stays
+responsive, CUDA state stays out of the node process, and the training can never run more than
+one item ahead of the bookkeeping. `find_batch_size` probes for the largest power-of-two batch
+that fits, around a `fits` predicate the trainer supplies — none of it imports torch, so a node
+brings its own way of running a step. `macro_f1` scores the confusion matrix
+`_get_new_best_training_state` returns.
+
 `helpers/entrypoint.py` holds what every node's `main.py` repeats: `node_parser` builds a
 configargparse parser with `--host`/`--port`, `run_node` starts uvicorn. A setting is a flag
 *and* an environment variable from one declaration — `--conf-threshold` reads

--- a/learning_loop_node/detector/geometry.py
+++ b/learning_loop_node/detector/geometry.py
@@ -1,0 +1,69 @@
+"""Box and point clipping shared by every detector node.
+
+The loop stores a box as its top-left corner plus a size, so :func:`clip_box` is the form a
+node needs when it hands detections to the loop. Model outputs are not always in that form —
+:func:`clip_box_centered` keeps the centre-based convention explicit instead of letting two
+incompatible functions share one name, which is how the same helper ended up meaning two
+different things in different node repositories.
+"""
+
+
+def clip_box(
+    *,
+    x1: float,
+    y1: float,
+    width: float,
+    height: float,
+    img_width: int,
+    img_height: int,
+) -> tuple[int, int, int, int]:
+    """Clip a top-left-anchored box to the image bounds.
+
+    :param x1: Left edge of the box.
+    :param y1: Top edge of the box.
+    :return: The clipped ``(x1, y1, width, height)`` as ints; the size is never negative.
+    """
+    x2 = x1 + width
+    y2 = y1 + height
+
+    clipped_x1 = round(max(0.0, x1))
+    clipped_y1 = round(max(0.0, y1))
+    clipped_x2 = round(min(float(img_width), x2))
+    clipped_y2 = round(min(float(img_height), y2))
+
+    clipped_width = max(clipped_x2 - clipped_x1, 0)
+    clipped_height = max(clipped_y2 - clipped_y1, 0)
+
+    return clipped_x1, clipped_y1, clipped_width, clipped_height
+
+
+def clip_box_centered(
+    *,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    img_width: int,
+    img_height: int,
+) -> tuple[float, float, float, float]:
+    """Clip a centre-anchored box to the image bounds, keeping it centre-anchored.
+
+    Clipping moves the centre, because only the part of the box inside the image survives.
+
+    :param x: Horizontal centre of the box.
+    :param y: Vertical centre of the box.
+    :return: The clipped ``(x, y, width, height)``, still centre-anchored.
+    """
+    left = max(0.0, x - 0.5 * width)
+    top = max(0.0, y - 0.5 * height)
+    right = min(float(img_width), x + 0.5 * width)
+    bottom = min(float(img_height), y + 0.5 * height)
+
+    return 0.5 * (left + right), 0.5 * (top + bottom), right - left, bottom - top
+
+
+def clip_point(x: float, y: float, img_width: int, img_height: int) -> tuple[float, float]:
+    """Clamp a point into the image bounds."""
+    x = min(max(0, x), img_width)
+    y = min(max(0, y), img_height)
+    return x, y

--- a/learning_loop_node/detector/postprocess.py
+++ b/learning_loop_node/detector/postprocess.py
@@ -1,0 +1,264 @@
+"""Model-agnostic detection postprocessing.
+
+Every detection node ends up doing the same three things with a model's raw output: drop
+low-confidence predictions, suppress overlapping boxes, and turn what survives into the
+loop's detection dataclasses. None of that depends on the model, so it lives here rather
+than being re-derived — and re-diverging — in each node repository.
+
+Two containers carry the same detections in this library: a detector node reports
+:class:`~learning_loop_node.data_classes.image_metadata.ImageMetadata`, while a trainer's
+auto-detection pass reports :class:`~learning_loop_node.data_classes.detections.Detections`.
+:func:`to_image_metadata` and :func:`to_detections` build them from the same routine, so both
+paths clip and filter identically.
+"""
+
+import logging
+from collections import namedtuple
+
+import numpy as np
+
+from ..data_classes import (
+    BoxDetection,
+    Category,
+    Detections,
+    ImageMetadata,
+    ModelInformation,
+    PointDetection,
+)
+from ..enums import CategoryType
+from .geometry import clip_box, clip_point
+
+MIN_BOX_SIZE: int = 2
+"""Boxes this small are dropped: they carry no usable information and clutter the loop."""
+
+Detection = namedtuple('Detection', 'x y w h category probability')
+"""One surviving prediction. ``x``/``y`` are the top-left corner, ``category`` is an index
+into :attr:`ModelInformation.categories`."""
+
+
+def category_by_index(model_information: ModelInformation, index: int) -> Category:
+    """Resolve the category a model's class index refers to.
+
+    Models emit class indices, and the order of ``model_information.categories`` is what
+    gives them meaning — so an out-of-range index is a model/metadata mismatch, not a
+    detection to skip quietly.
+
+    :raises ValueError: If the index is outside the model's category list.
+    """
+    categories = model_information.categories
+    if not 0 <= index < len(categories):
+        raise ValueError(
+            f'category index {index} is out of range for a model with {len(categories)} categories')
+    return categories[index]
+
+
+def category_by_name(model_information: ModelInformation, name: str) -> Category:
+    """Resolve a category by name, for models whose outputs are named rather than indexed.
+
+    :raises ValueError: If no category of that name exists.
+    """
+    for category in model_information.categories:
+        if category.name == name:
+            return category
+    known = ', '.join(category.name for category in model_information.categories)
+    raise ValueError(f'unknown category name {name!r}; the model knows: {known}')
+
+
+def bbox_iou(
+    box1: np.ndarray,
+    box2: np.ndarray,
+) -> np.ndarray:
+    """Compute IoU between box1 (1x4) and box2 (Nx4), both in x1y1x2y2 format."""
+    b1_x1, b1_y1, b1_x2, b1_y2 = box1[:, 0], box1[:, 1], box1[:, 2], box1[:, 3]
+    b2_x1, b2_y1, b2_x2, b2_y2 = box2[:, 0], box2[:, 1], box2[:, 2], box2[:, 3]
+
+    inter_x1 = np.maximum(b1_x1, b2_x1)
+    inter_y1 = np.maximum(b1_y1, b2_y1)
+    inter_x2 = np.minimum(b1_x2, b2_x2)
+    inter_y2 = np.minimum(b1_y2, b2_y2)
+
+    inter_area = np.clip(inter_x2 - inter_x1 + 1, 0, None) * np.clip(inter_y2 - inter_y1 + 1, 0, None)
+    b1_area = (b1_x2 - b1_x1 + 1) * (b1_y2 - b1_y1 + 1)
+    b2_area = (b2_x2 - b2_x1 + 1) * (b2_y2 - b2_y1 + 1)
+
+    return inter_area / (b1_area + b2_area - inter_area + 1e-16)
+
+
+def non_max_suppression(
+    boxes: np.ndarray,
+    scores: np.ndarray,
+    classes: np.ndarray,
+    *,
+    iou_threshold: float,
+    origin_h: int,
+    origin_w: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Clip to image bounds, sort by score descending, apply per-class NMS.
+
+    :return: ``(boxes, scores, classes)`` — filtered arrays in the same order.
+    """
+    boxes = boxes.copy()
+    boxes[:, 0] = np.clip(boxes[:, 0], 0, origin_w - 1)
+    boxes[:, 2] = np.clip(boxes[:, 2], 0, origin_w - 1)
+    boxes[:, 1] = np.clip(boxes[:, 1], 0, origin_h - 1)
+    boxes[:, 3] = np.clip(boxes[:, 3], 0, origin_h - 1)
+
+    order = np.argsort(-scores)
+    boxes = boxes[order]
+    scores = scores[order]
+    classes = classes[order]
+
+    keep_indices: list[int] = []
+    for cls in np.unique(classes):
+        cls_mask = classes == cls
+        cls_indices = np.where(cls_mask)[0]
+        cls_boxes = boxes[cls_mask]
+
+        while len(cls_indices) > 0:
+            keep_indices.append(cls_indices[0])
+            if len(cls_indices) == 1:
+                break
+            ious = bbox_iou(cls_boxes[0:1], cls_boxes[1:])
+            keep_mask = ious.flatten() <= iou_threshold
+            cls_indices = cls_indices[1:][keep_mask]
+            cls_boxes = cls_boxes[1:][keep_mask]
+
+    keep_indices = sorted(keep_indices)
+    return boxes[keep_indices], scores[keep_indices], classes[keep_indices]
+
+
+def post_process(
+    boxes: np.ndarray,
+    scores: np.ndarray,
+    classes: np.ndarray,
+    *,
+    conf_threshold: float,
+    iou_threshold: float,
+    origin_h: int,
+    origin_w: int,
+) -> list[Detection]:
+    """Filter by confidence, run NMS, return a :class:`Detection` list in x/y/w/h form."""
+    mask = scores > conf_threshold
+    boxes = boxes[mask].copy()
+    scores = scores[mask]
+    classes = classes[mask]
+
+    if len(scores) == 0:
+        return []
+
+    boxes, scores, classes = non_max_suppression(
+        boxes, scores, classes,
+        iou_threshold=iou_threshold, origin_h=origin_h, origin_w=origin_w)
+
+    result = []
+    for j, box in enumerate(boxes):
+        x1, y1, x2, y2 = box
+        w = x2 - x1
+        h = y2 - y1
+        result.append(Detection(int(x1), int(y1), int(w), int(h),
+                                int(classes[j]), round(float(scores[j]), 2)))
+    return result
+
+
+def detections_from_xyxy(
+    *,
+    labels: list[float],
+    boxes: list[list[float]],
+    scores: list[float],
+) -> list[Detection]:
+    """Convert already-suppressed model output into :class:`Detection` values.
+
+    For nodes whose model (or a torch/ONNX op) has done the suppression already, so only the
+    coordinate conversion is left. Corners are rounded rather than truncated, which is half a
+    pixel more faithful than :func:`post_process` — that one keeps truncating so its output
+    stays bit-identical to what detectors reported before this module existed.
+    """
+    result = []
+    for label, box, score in zip(labels, boxes, scores, strict=True):
+        x1, y1, x2, y2 = (round(value) for value in box)
+        result.append(Detection(x1, y1, x2 - x1, y2 - y1, int(label), score))
+    return result
+
+
+def _append_detections(
+    target: ImageMetadata | Detections,
+    detections: list[Detection],
+    model_information: ModelInformation,
+    im_height: int,
+    im_width: int,
+) -> None:
+    """Resolve each detection's category and append it to ``target``, clipped to the image."""
+    skipped_detections = []
+
+    for detection in detections:
+        x, y, w, h, category_idx, probability = detection
+        category = category_by_index(model_information, category_idx)
+        if w <= MIN_BOX_SIZE or h <= MIN_BOX_SIZE:
+            skipped_detections.append((category.name, detection))
+            continue
+        if category.type == CategoryType.Box:
+            clipped_x1, clipped_y1, clipped_w, clipped_h = clip_box(
+                x1=x,
+                y1=y,
+                width=w,
+                height=h,
+                img_width=im_width,
+                img_height=im_height,
+            )
+            target.box_detections.append(
+                BoxDetection(
+                    category_name=category.name,
+                    x=clipped_x1,
+                    y=clipped_y1,
+                    width=clipped_w,
+                    height=clipped_h,
+                    category_id=category.id,
+                    model_name=model_information.version,
+                    confidence=probability,
+                )
+            )
+        elif category.type == CategoryType.Point:
+            cx, cy = x + w / 2, y + h / 2
+            cx, cy = clip_point(cx, cy, im_width, im_height)
+            target.point_detections.append(
+                PointDetection(
+                    category_name=category.name,
+                    x=cx,
+                    y=cy,
+                    category_id=category.id,
+                    model_name=model_information.version,
+                    confidence=probability,
+                )
+            )
+        else:
+            logging.warning('Unsupported category type %s for category %s', category.type, category.name)
+
+    if skipped_detections:
+        log_msg = '\n'.join([str(d) for d in skipped_detections])
+        logging.warning('Removed %d small detections from result: \n%s', len(skipped_detections), log_msg)
+
+
+def to_image_metadata(
+    detections: list[Detection],
+    model_information: ModelInformation,
+    im_height: int,
+    im_width: int,
+) -> ImageMetadata:
+    """Build the container a *detector* node reports from a list of detections."""
+    image_metadata = ImageMetadata()
+    _append_detections(image_metadata, detections, model_information, im_height, im_width)
+    return image_metadata
+
+
+def to_detections(
+    detections: list[Detection],
+    model_information: ModelInformation,
+    im_height: int,
+    im_width: int,
+    *,
+    image_id: str | None = None,
+) -> Detections:
+    """Build the container a *trainer*'s auto-detection pass reports."""
+    result = Detections(image_id=image_id)
+    _append_detections(result, detections, model_information, im_height, im_width)
+    return result

--- a/learning_loop_node/helpers/entrypoint.py
+++ b/learning_loop_node/helpers/entrypoint.py
@@ -1,0 +1,75 @@
+"""The boilerplate every node's ``main.py`` repeats.
+
+A node entry point always does the same four things: read a handful of settings, build the
+logic object, construct the node, and hand it to uvicorn. Only the middle two are the node's
+own, so :func:`node_parser` and :func:`run_node` cover the rest.
+
+Settings come from a flag *or* an environment variable, because a node is configured on the
+command line while developing and through the container environment in deployment. One
+declaration gives both: ``--conf-threshold`` reads ``CONF_THRESHOLD``.
+
+``--host`` and ``--port`` are the exception — they read ``NODE_HOST`` and ``NODE_PORT`` rather
+than the names their flags imply, because the bare ``HOST`` already means *the loop's address*
+and a node adopting it would hand it to uvicorn and fail to bind.
+"""
+
+import logging
+import os
+from argparse import Action, Namespace
+
+import configargparse
+import uvicorn
+
+
+def node_parser(*, description: str, legacy_env_prefix: str = '') -> configargparse.ArgumentParser:
+    """Build the parser for a node, pre-loaded with the settings every node has.
+
+    :param legacy_env_prefix: A prefix an earlier version of this node required, e.g.
+        ``'DFINE_DETECTOR_'``. Prefixed names are still honoured, with a warning, so a
+        deployment keeps working until it is updated. Leave empty for a node that has always
+        read unprefixed names.
+    """
+    parser = _NodeArgumentParser(description=description, legacy_env_prefix=legacy_env_prefix)
+    parser.add_argument('--host', default='0.0.0.0', env_var='NODE_HOST',
+                        help='Host interface to bind to')
+    parser.add_argument('--port', type=int, default=80, env_var='NODE_PORT', help='Port to bind to')
+    return parser
+
+
+def run_node(app: str, args: Namespace) -> None:
+    """Serve the node.
+
+    :param app: Import string of the node object, conventionally ``'main:node'``.
+    """
+    reload = os.getenv('UVICORN_RELOAD', 'FALSE').lower() in ('true', '1')
+    logging.info('Uvicorn reload is set to: %s', reload)
+    uvicorn.run(app, host=args.host, port=args.port, lifespan='on', reload=reload)
+
+
+class _NodeArgumentParser(configargparse.ArgumentParser):
+    """Parser whose every setting is also an environment variable named after its flag."""
+
+    def __init__(self, *, description: str, legacy_env_prefix: str) -> None:
+        super().__init__(description=description)
+        self.legacy_env_prefix = legacy_env_prefix
+
+    def add_argument(self, *args, **kwargs) -> Action:  # type: ignore[override]
+        action = super().add_argument(*args, **kwargs)
+        if getattr(action, 'env_var', None) is None and action.dest != 'help':
+            action.env_var = action.dest.upper()
+        return action
+
+    def parse_args(self, *args, **kwargs) -> Namespace:  # type: ignore[override]
+        self._adopt_legacy_env_vars()
+        return super().parse_args(*args, **kwargs)
+
+    def _adopt_legacy_env_vars(self) -> None:
+        if not self.legacy_env_prefix:
+            return
+        for action in self._actions:
+            name = getattr(action, 'env_var', None)
+            legacy = self.legacy_env_prefix + name if name else None
+            if not legacy or name in os.environ or legacy not in os.environ:
+                continue
+            os.environ[name] = os.environ[legacy]
+            logging.warning('%s is deprecated and will stop being read; set %s instead', legacy, name)

--- a/learning_loop_node/helpers/environment_reader.py
+++ b/learning_loop_node/helpers/environment_reader.py
@@ -15,12 +15,15 @@ def read_from_env(possible_names: List[str], ignore_errors: bool = True) -> Opti
             return None
         raise ValueError(f'no environment variable set for {possible_names}')
 
-    # Possible error: multiple values are not None and not equal
+    # Possible error: multiple values are not None and not equal.
+    # NOTE returning None here would be worse than picking one: the caller falls back to its
+    # default, and host()'s default is the production loop. `possible_names` is ordered by
+    # preference, so a disagreement resolves to the first name that is set.
     if len(values) > 1 and len(set(values)) > 1:
-        if ignore_errors:
-            logging.warning('different environment variables set for %s: %s', possible_names, values)
-            return None
-        raise ValueError(f'different environment variables set for {possible_names}: {values}')
+        if not ignore_errors:
+            raise ValueError(f'different environment variables set for {possible_names}: {values}')
+        logging.warning('different environment variables set for %s: %s - using %s',
+                        possible_names, values, values[0])
 
     return values[0]
 

--- a/learning_loop_node/tests/unit/pytest.ini
+++ b/learning_loop_node/tests/unit/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+python_files = test_*.py
+asyncio_mode = auto
+
+cache_dir = /tmp/pytest_cache 
+    
+# for debbuging tests:
+; log_cli_level = INFO
+; log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+; log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/learning_loop_node/tests/unit/test_batch_size.py
+++ b/learning_loop_node/tests/unit/test_batch_size.py
@@ -1,0 +1,118 @@
+from collections.abc import Callable
+
+import pytest
+
+from ...trainer.batch_size import (
+    MIN_TRAIN_STEPS_PER_EPOCH,
+    batch_count,
+    dataset_limit,
+    find_batch_size,
+    is_out_of_memory,
+    no_gpu_batch_size,
+    smaller_pot,
+)
+
+
+def _recording(capacity: int) -> tuple[Callable[[int], bool], list[int]]:
+    """A `fits` predicate for a machine of `capacity`, plus the sizes it gets asked about."""
+    calls: list[int] = []
+
+    def fits(batch_size: int) -> bool:
+        calls.append(batch_size)
+        return batch_size <= capacity
+
+    return fits, calls
+
+
+def _fits_up_to(capacity: int) -> Callable[[int], bool]:
+    fits, _ = _recording(capacity)
+    return fits
+
+
+def test_the_search_doubles_up_to_the_limit():
+    fits, calls = _recording(1024)
+    assert find_batch_size(fits, limit=16) == 16
+    assert calls == [1, 2, 4, 8, 16]
+
+
+def test_the_search_backs_off_to_the_last_size_that_fit():
+    fits, calls = _recording(20)
+    assert find_batch_size(fits, limit=64) == 16
+    assert calls == [1, 2, 4, 8, 16, 32]  # probes 32, fails, keeps 16
+
+
+def test_a_limit_that_is_not_a_power_of_two_is_rounded_down():
+    assert find_batch_size(_fits_up_to(1024), limit=48) == 32
+    assert find_batch_size(_fits_up_to(1024), limit=1) == 1
+
+
+def test_a_machine_that_cannot_take_one_sample_is_an_error():
+    fits, calls = _recording(0)
+    with pytest.raises(RuntimeError, match='batch size 1 does not fit'):
+        find_batch_size(fits, limit=64)
+    assert calls == [1], 'must give up instead of probing larger sizes'
+
+
+@pytest.mark.parametrize('capacity', range(1, 130))
+def test_the_result_is_always_the_largest_power_of_two_that_fits(capacity: int):
+    assert find_batch_size(_fits_up_to(capacity), limit=512) == smaller_pot(capacity)
+
+
+def test_equal_hardware_yields_an_equal_recipe():
+    """Only powers of two, so two machines of similar size train identically."""
+    assert find_batch_size(_fits_up_to(37), limit=512) == find_batch_size(_fits_up_to(39), limit=512)
+
+
+def test_smaller_pot():
+    assert [smaller_pot(n) for n in (1, 2, 3, 4, 7, 8, 15, 1293)] == [1, 2, 2, 4, 4, 8, 8, 1024]
+    with pytest.raises(ValueError, match='n must be >= 1'):
+        smaller_pot(0)
+
+
+def test_batch_count_covers_the_whole_set_without_overshooting_by_a_batch():
+    for sample_count in (1, 7, 8, 900, 5000):
+        for batch_size in (1, 2, 8, 64, 512):
+            covered = batch_count(sample_count, batch_size) * batch_size
+            assert covered >= sample_count
+            assert covered - sample_count < batch_size
+
+
+def test_the_dataset_limit_keeps_enough_steps_per_epoch():
+    for sample_count in (8, 20, 47, 100, 1000, 118_000):
+        limit = smaller_pot(dataset_limit(sample_count))
+        assert sample_count // limit >= MIN_TRAIN_STEPS_PER_EPOCH
+
+
+def test_the_dataset_limit_stays_usable_for_a_tiny_set():
+    assert dataset_limit(7) == 1
+    with pytest.raises(ValueError, match='sample_count must be >= 1'):
+        dataset_limit(0)
+
+
+def test_memory_still_decides_below_the_dataset_limit():
+    """The bound is a ceiling only: a card that fits just 2 keeps training at 2."""
+    assert find_batch_size(_fits_up_to(2), limit=dataset_limit(20)) == 2
+
+
+def test_without_a_gpu_the_fallback_respects_the_limit():
+    assert no_gpu_batch_size(1024, 'probe') == 8
+    assert no_gpu_batch_size(2, 'probe') == 2
+
+
+@pytest.mark.parametrize('message', [
+    'CUDA out of memory. Tried to allocate 20.00 MiB',
+    'cuDNN error: CUDNN_STATUS_ALLOC_FAILED',
+    'CUDA error: unknown error',
+])
+def test_allocation_failures_are_recognised_however_they_surface(message: str):
+    assert is_out_of_memory(RuntimeError(message))
+
+
+def test_a_real_bug_is_not_mistaken_for_a_full_card():
+    """A trainer catching bare RuntimeError treats every crash as 'too big'; this does not."""
+    assert not is_out_of_memory(RuntimeError('shape mismatch in forward pass'))
+    assert not is_out_of_memory(ValueError('bad config'))
+
+
+def test_the_host_running_out_of_memory_counts_too():
+    assert is_out_of_memory(MemoryError())

--- a/learning_loop_node/tests/unit/test_entrypoint.py
+++ b/learning_loop_node/tests/unit/test_entrypoint.py
@@ -1,0 +1,71 @@
+import pytest
+
+from ...helpers.entrypoint import node_parser
+
+MANAGED = ('WEIGHT_TYPE', 'DFINE_DETECTOR_WEIGHT_TYPE', 'HOST', 'NODE_HOST', 'NODE_PORT', 'PORT')
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch):
+    """Every test starts without the variables it is about to set."""
+    for name in MANAGED:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _parser(**kwargs):
+    parser = node_parser(description='a node', **kwargs)
+    parser.add_argument('--weight-type', default='FP16')
+    return parser
+
+
+def test_every_node_gets_a_host_and_a_port():
+    args = _parser().parse_args([])
+    assert (args.host, args.port) == ('0.0.0.0', 80)
+
+
+def test_a_flag_beats_everything():
+    args = _parser().parse_args(['--weight-type', 'FP32'])
+    assert args.weight_type == 'FP32'
+
+
+def test_a_setting_is_read_from_the_variable_named_after_its_flag(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('WEIGHT_TYPE', 'FP32')
+    assert _parser().parse_args([]).weight_type == 'FP32'
+
+
+def test_the_loop_own_host_is_never_mistaken_for_the_bind_address(monkeypatch: pytest.MonkeyPatch):
+    """HOST is the loop's address. Binding uvicorn to it would leave the node unreachable."""
+    monkeypatch.setenv('HOST', 'preview.learning-loop.ai')
+    assert _parser().parse_args([]).host == '0.0.0.0'
+
+
+def test_the_bind_address_has_a_name_of_its_own(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('NODE_HOST', '127.0.0.1')
+    monkeypatch.setenv('NODE_PORT', '8080')
+    args = _parser().parse_args([])
+    assert (args.host, args.port) == ('127.0.0.1', 8080)
+
+
+def test_a_node_that_used_a_prefix_still_reads_it(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('DFINE_DETECTOR_WEIGHT_TYPE', 'FP32')
+    parser = _parser(legacy_env_prefix='DFINE_DETECTOR_')
+    assert parser.parse_args([]).weight_type == 'FP32'
+
+
+def test_the_prefixed_name_warns_which_one_to_use_instead(monkeypatch: pytest.MonkeyPatch,
+                                                          caplog: pytest.LogCaptureFixture):
+    monkeypatch.setenv('DFINE_DETECTOR_WEIGHT_TYPE', 'FP32')
+    _parser(legacy_env_prefix='DFINE_DETECTOR_').parse_args([])
+    assert 'DFINE_DETECTOR_WEIGHT_TYPE' in caplog.text
+    assert 'WEIGHT_TYPE' in caplog.text
+
+
+def test_the_current_name_wins_over_the_prefixed_one(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('DFINE_DETECTOR_WEIGHT_TYPE', 'FP32')
+    monkeypatch.setenv('WEIGHT_TYPE', 'FP16')
+    assert _parser(legacy_env_prefix='DFINE_DETECTOR_').parse_args([]).weight_type == 'FP16'
+
+
+def test_a_node_without_a_legacy_prefix_ignores_prefixed_names(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('DFINE_DETECTOR_WEIGHT_TYPE', 'FP32')
+    assert _parser().parse_args([]).weight_type == 'FP16'

--- a/learning_loop_node/tests/unit/test_environment_reader.py
+++ b/learning_loop_node/tests/unit/test_environment_reader.py
@@ -1,0 +1,51 @@
+"""Tests for `helpers/environment_reader`, which resolves every loop setting a node reads."""
+
+import pytest
+
+from ...helpers import environment_reader
+
+NAMES = ('LOOP_HOST', 'HOST', 'LOOP_ORGANIZATION', 'ORGANIZATION')
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch):
+    for name in NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_the_prefixed_name_is_preferred(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('LOOP_HOST', 'preview.learning-loop.ai')
+    monkeypatch.setenv('HOST', 'preview.learning-loop.ai')
+    assert environment_reader.host() == 'preview.learning-loop.ai'
+
+
+def test_either_name_alone_is_read(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('HOST', 'preview.learning-loop.ai')
+    assert environment_reader.host() == 'preview.learning-loop.ai'
+    monkeypatch.delenv('HOST')
+    monkeypatch.setenv('LOOP_HOST', 'other.learning-loop.ai')
+    assert environment_reader.host() == 'other.learning-loop.ai'
+
+
+def test_a_disagreement_resolves_to_the_preferred_name(monkeypatch: pytest.MonkeyPatch):
+    """Returning nothing here would let host() fall back to its default, which is production."""
+    monkeypatch.setenv('LOOP_HOST', 'preview.learning-loop.ai')
+    monkeypatch.setenv('HOST', 'learning-loop.ai')
+    assert environment_reader.host(default='learning-loop.ai') == 'preview.learning-loop.ai'
+
+
+def test_a_disagreement_falls_back_to_the_second_name_when_the_first_is_unset(
+        monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('ORGANIZATION', 'zauberzeug')
+    assert environment_reader.organization() == 'zauberzeug'
+
+
+def test_a_disagreement_still_raises_when_errors_are_not_ignored(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('LOOP_HOST', 'a')
+    monkeypatch.setenv('HOST', 'b')
+    with pytest.raises(ValueError, match='different environment variables'):
+        environment_reader.read_from_env(['LOOP_HOST', 'HOST'], ignore_errors=False)
+
+
+def test_nothing_set_yields_the_default():
+    assert environment_reader.host(default='fallback') == 'fallback'

--- a/learning_loop_node/tests/unit/test_geometry.py
+++ b/learning_loop_node/tests/unit/test_geometry.py
@@ -1,0 +1,35 @@
+from ...detector.geometry import clip_box, clip_box_centered, clip_point
+
+
+def test_box_inside_the_image_is_unchanged():
+    assert clip_box(x1=10, y1=20, width=30, height=40, img_width=100, img_height=100) == (10, 20, 30, 40)
+
+
+def test_box_is_clipped_to_the_image_bounds():
+    assert clip_box(x1=-20, y1=-20, width=60, height=60, img_width=100, img_height=100) == (0, 0, 40, 40)
+    assert clip_box(x1=80, y1=80, width=40, height=40, img_width=100, img_height=100) == (80, 80, 20, 20)
+
+
+def test_box_fully_outside_the_image_collapses_to_zero_size():
+    # The corner is only clamped at the lower bound, so it stays at 200 — the zero size is
+    # what marks the box as empty. Detector output cannot reach here, because
+    # non_max_suppression already clips every box into the image.
+    assert clip_box(x1=200, y1=200, width=10, height=10, img_width=100, img_height=100) == (200, 200, 0, 0)
+
+
+def test_box_corners_are_rounded():
+    assert clip_box(x1=10.4, y1=10.6, width=20.0, height=20.0, img_width=100, img_height=100) == (10, 11, 20, 20)
+
+
+def test_centered_box_keeps_its_centre_when_it_fits():
+    assert clip_box_centered(x=50, y=50, width=20, height=20, img_width=100, img_height=100) == (50, 50, 20, 20)
+
+
+def test_clipping_a_centered_box_moves_its_centre():
+    # only the right half of the box is inside the image, so the centre moves right
+    assert clip_box_centered(x=0, y=50, width=20, height=20, img_width=100, img_height=100) == (5, 50, 10, 20)
+
+
+def test_point_is_clamped_into_the_image():
+    assert clip_point(50, 50, 100, 100) == (50, 50)
+    assert clip_point(-10, 150, 100, 100) == (0, 100)

--- a/learning_loop_node/tests/unit/test_metrics.py
+++ b/learning_loop_node/tests/unit/test_metrics.py
@@ -1,0 +1,39 @@
+import pytest
+
+from ...trainer.metrics import category_f1, confusion_matrix_from_counts, macro_f1
+
+
+def test_the_score_averages_the_categories_instead_of_pooling_them():
+    """Counts from a real epoch: face 248/19/59 and hand 39/54/73 - 74% pooled, 62% averaged."""
+    assert macro_f1({'face': {'tp': 248, 'fp': 19, 'fn': 59},
+                     'hand': {'tp': 39, 'fp': 54, 'fn': 73}}) == pytest.approx(0.622, abs=0.001)
+    assert macro_f1({'both': {'tp': 287, 'fp': 73, 'fn': 132}}) == pytest.approx(0.737, abs=0.001)
+
+
+def test_a_rare_category_carries_the_same_weight():
+    """A category the model never finds halves the score, however few instances it has."""
+    assert macro_f1({'frequent': {'tp': 1000, 'fp': 0, 'fn': 0},
+                     'rare': {'tp': 0, 'fp': 0, 'fn': 3}}) == pytest.approx(0.5)
+
+
+def test_a_category_without_any_counts_scores_zero_instead_of_raising():
+    assert macro_f1({'unseen': {'tp': 0, 'fp': 0, 'fn': 0}}) == 0.0
+    assert category_f1({'tp': 0, 'fp': 0, 'fn': 0}) == 0.0
+
+
+def test_an_empty_confusion_matrix_scores_zero():
+    assert macro_f1({}) == 0.0
+
+
+def test_a_perfect_category_scores_one():
+    assert category_f1({'tp': 10, 'fp': 0, 'fn': 0}) == pytest.approx(1.0)
+
+
+def test_precision_and_recall_are_balanced():
+    assert category_f1({'tp': 5, 'fp': 5, 'fn': 0}) == category_f1({'tp': 5, 'fp': 0, 'fn': 5})
+
+
+def test_counts_can_be_assembled_from_separate_mappings():
+    matrix = confusion_matrix_from_counts({'a': 3}, {'a': 1, 'b': 2}, {'b': 4})
+    assert matrix == {'a': {'tp': 3, 'fp': 1, 'fn': 0},
+                      'b': {'tp': 0, 'fp': 2, 'fn': 4}}

--- a/learning_loop_node/tests/unit/test_postprocess.py
+++ b/learning_loop_node/tests/unit/test_postprocess.py
@@ -1,0 +1,168 @@
+import numpy as np
+import pytest
+
+from ...data_classes import Category, ModelInformation
+from ...detector.postprocess import (
+    Detection,
+    bbox_iou,
+    category_by_index,
+    category_by_name,
+    detections_from_xyxy,
+    non_max_suppression,
+    post_process,
+    to_detections,
+    to_image_metadata,
+)
+from ...enums import CategoryType
+
+BOX = Category(id='uuid-box', name='car', type=CategoryType.Box)
+POINT = Category(id='uuid-point', name='weed', type=CategoryType.Point)
+
+
+def model_information(*categories: Category) -> ModelInformation:
+    return ModelInformation(id='model-uuid', host='localhost', organization='zauberzeug',
+                            project='pytest', version='1.2', categories=list(categories or (BOX, POINT)))
+
+
+# ---------------------------------------------------------------- category resolution
+
+def test_category_is_resolved_by_index():
+    assert category_by_index(model_information(), 1) is POINT
+
+
+@pytest.mark.parametrize('index', [-1, 2, 99])
+def test_an_index_outside_the_model_categories_is_an_error(index: int):
+    # a mismatch between model and metadata must not be silently skipped
+    with pytest.raises(ValueError, match='out of range'):
+        category_by_index(model_information(), index)
+
+
+def test_category_is_resolved_by_name():
+    assert category_by_name(model_information(), 'weed') is POINT
+
+
+def test_an_unknown_category_name_lists_the_known_ones():
+    with pytest.raises(ValueError, match='car, weed'):
+        category_by_name(model_information(), 'tractor')
+
+
+# ---------------------------------------------------------------- iou and suppression
+
+def test_identical_boxes_have_an_iou_of_one():
+    box = np.array([[0, 0, 10, 10]], dtype=np.float32)
+    assert bbox_iou(box, box)[0] == pytest.approx(1.0)
+
+
+def test_disjoint_boxes_have_an_iou_of_zero():
+    a = np.array([[0, 0, 10, 10]], dtype=np.float32)
+    b = np.array([[100, 100, 110, 110]], dtype=np.float32)
+    assert bbox_iou(a, b)[0] == pytest.approx(0.0)
+
+
+def test_overlapping_boxes_of_one_class_are_suppressed_keeping_the_best():
+    boxes = np.array([[10, 10, 60, 60], [12, 12, 62, 62]], dtype=np.float32)
+    scores = np.array([0.9, 0.8], dtype=np.float32)
+    kept_boxes, kept_scores, _ = non_max_suppression(
+        boxes, scores, np.array([0, 0]), iou_threshold=0.45, origin_h=200, origin_w=200)
+    assert len(kept_boxes) == 1
+    assert kept_scores[0] == pytest.approx(0.9)
+
+
+def test_overlapping_boxes_of_different_classes_both_survive():
+    boxes = np.array([[10, 10, 60, 60], [12, 12, 62, 62]], dtype=np.float32)
+    kept_boxes, _, _ = non_max_suppression(
+        boxes, np.array([0.9, 0.8], dtype=np.float32), np.array([0, 1]),
+        iou_threshold=0.45, origin_h=200, origin_w=200)
+    assert len(kept_boxes) == 2
+
+
+def test_suppression_clips_boxes_into_the_image():
+    boxes = np.array([[-10, -10, 300, 300]], dtype=np.float32)
+    kept_boxes, _, _ = non_max_suppression(
+        boxes, np.array([0.9], dtype=np.float32), np.array([0]),
+        iou_threshold=0.45, origin_h=100, origin_w=100)
+    assert list(kept_boxes[0]) == [0, 0, 99, 99]
+
+
+# ---------------------------------------------------------------- post_process
+
+def test_post_process_drops_predictions_below_the_confidence_threshold():
+    boxes = np.array([[10, 10, 60, 60], [100, 100, 150, 150]], dtype=np.float32)
+    result = post_process(boxes, np.array([0.9, 0.1], dtype=np.float32), np.array([0, 0]),
+                          conf_threshold=0.5, iou_threshold=0.45, origin_h=200, origin_w=200)
+    assert result == [Detection(10, 10, 50, 50, 0, 0.9)]
+
+
+def test_post_process_on_an_empty_prediction_returns_nothing():
+    empty_boxes = np.zeros((0, 4), dtype=np.float32)
+    assert post_process(empty_boxes, np.zeros(0, dtype=np.float32), np.zeros(0, dtype=int),
+                        conf_threshold=0.5, iou_threshold=0.45, origin_h=10, origin_w=10) == []
+
+
+def test_already_suppressed_output_is_converted_with_rounded_corners():
+    assert detections_from_xyxy(labels=[1.0], boxes=[[10.4, 10.6, 60.4, 60.6]], scores=[0.55]) == \
+        [Detection(10, 11, 50, 50, 1, 0.55)]
+
+
+def test_converting_already_suppressed_output_requires_matching_lengths():
+    with pytest.raises(ValueError):
+        detections_from_xyxy(labels=[1.0, 2.0], boxes=[[0.0, 0.0, 1.0, 1.0]], scores=[0.5])
+
+
+# ---------------------------------------------------------------- building the containers
+
+def test_a_box_category_becomes_a_box_detection():
+    metadata = to_image_metadata([Detection(10, 20, 30, 40, 0, 0.9)], model_information(), 200, 200)
+    assert len(metadata.point_detections) == 0
+    detection = metadata.box_detections[0]
+    assert (detection.x, detection.y, detection.width, detection.height) == (10, 20, 30, 40)
+    assert (detection.category_name, detection.category_id) == ('car', 'uuid-box')
+    assert detection.model_name == '1.2'
+    assert detection.confidence == pytest.approx(0.9)
+
+
+def test_a_point_category_becomes_the_centre_of_the_box():
+    metadata = to_image_metadata([Detection(100, 100, 40, 40, 1, 0.7)], model_information(), 200, 200)
+    assert len(metadata.box_detections) == 0
+    detection = metadata.point_detections[0]
+    assert (detection.x, detection.y) == (120, 120)
+    assert detection.category_id == 'uuid-point'
+
+
+def test_detections_are_clipped_to_the_image():
+    metadata = to_image_metadata([Detection(-20, -20, 60, 60, 0, 0.5)], model_information(), 200, 200)
+    detection = metadata.box_detections[0]
+    assert (detection.x, detection.y, detection.width, detection.height) == (0, 0, 40, 40)
+
+
+@pytest.mark.parametrize('width,height', [(2, 30), (30, 2), (1, 1)])
+def test_boxes_too_small_to_be_useful_are_dropped(width: int, height: int):
+    metadata = to_image_metadata([Detection(5, 5, width, height, 0, 0.5)], model_information(), 200, 200)
+    assert len(metadata) == 0
+
+
+def test_a_category_type_the_node_cannot_report_is_skipped():
+    classification = Category(id='uuid-cls', name='ripe', type=CategoryType.Classification)
+    metadata = to_image_metadata([Detection(10, 10, 30, 30, 0, 0.5)],
+                                 model_information(classification), 200, 200)
+    assert len(metadata) == 0
+
+
+def test_the_trainer_container_carries_the_image_id():
+    result = to_detections([Detection(10, 20, 30, 40, 0, 0.9)], model_information(), 200, 200,
+                           image_id='image-uuid')
+    assert result.image_id == 'image-uuid'
+    assert len(result.box_detections) == 1
+
+
+def test_trainer_and_detector_paths_agree_on_the_same_detections():
+    """The whole point of sharing this code: auto-detections and live detections must match."""
+    detections = [Detection(-5, -5, 60, 60, 0, 0.9), Detection(100, 100, 40, 40, 1, 0.7),
+                  Detection(5, 5, 1, 1, 0, 0.5)]
+    metadata = to_image_metadata(detections, model_information(), 200, 200)
+    result = to_detections(detections, model_information(), 200, 200, image_id='image-uuid')
+
+    assert [(d.x, d.y, d.width, d.height, d.category_id) for d in result.box_detections] == \
+        [(d.x, d.y, d.width, d.height, d.category_id) for d in metadata.box_detections]
+    assert [(d.x, d.y, d.category_id) for d in result.point_detections] == \
+        [(d.x, d.y, d.category_id) for d in metadata.point_detections]

--- a/learning_loop_node/tests/unit/test_subprocess.py
+++ b/learning_loop_node/tests/unit/test_subprocess.py
@@ -1,0 +1,54 @@
+import pytest
+
+from ...trainer.subprocess import iterator_cpu_bound
+
+
+def counting(limit: int):
+    yield from range(limit)
+
+
+def raising_after(limit: int):
+    yield from range(limit)
+    raise RuntimeError('the training crashed')
+
+
+def empty():
+    return iter(())
+
+
+async def _collect(iterator) -> list:
+    return [item async for item in iterator]
+
+
+async def test_everything_the_generator_yields_arrives_in_order():
+    async with iterator_cpu_bound(counting, 5) as iterator:
+        assert await _collect(iterator) == [0, 1, 2, 3, 4]
+
+
+async def test_a_generator_that_yields_nothing_simply_finishes():
+    async with iterator_cpu_bound(empty) as iterator:
+        assert await _collect(iterator) == []
+
+
+async def test_a_failure_in_the_process_is_raised_in_the_caller():
+    """Otherwise a crashed training would look like a training that finished."""
+    with pytest.raises(RuntimeError, match='the training crashed'):
+        async with iterator_cpu_bound(raising_after, 2) as iterator:
+            await _collect(iterator)
+
+
+async def test_what_the_generator_produced_before_failing_still_arrives():
+    received = []
+    with pytest.raises(RuntimeError):
+        async with iterator_cpu_bound(raising_after, 3) as iterator:
+            async for item in iterator:
+                received.append(item)
+    assert received == [0, 1, 2]
+
+
+async def test_leaving_early_does_not_leave_the_process_running():
+    async with iterator_cpu_bound(counting, 1000) as iterator:
+        async for item in iterator:
+            if item == 2:
+                break
+    # the context manager killed and joined the process; reaching here without hanging is the test

--- a/learning_loop_node/trainer/batch_size.py
+++ b/learning_loop_node/trainer/batch_size.py
@@ -1,0 +1,86 @@
+"""Choosing a batch size by probing, rather than configuring one.
+
+The largest batch that fits depends on the model, the image resolution and the card, so a
+configured value is either wrong on some machines or too small on all of them. Probing answers
+it directly: run a representative step at doubling sizes and keep the last one that survived.
+
+What "a representative step" means is the trainer's business — it supplies a ``fits`` predicate
+that runs a real step and reports whether it ran out of memory. Everything here is that
+predicate's scaffolding, and none of it imports a deep-learning framework.
+
+Only powers of two are visited, so equal hardware yields an equal recipe. That matters when a
+trainer scales its learning rate by the batch size: a probe that returned 37 on one machine and
+39 on another would make the two trainings quietly different.
+
+Adapted from PyTorch Lightning's ``BatchSizeFinder`` (power-scaling mode).
+Copyright The Lightning AI team. Licensed under the Apache License, Version 2.0.
+https://github.com/Lightning-AI/pytorch-lightning
+"""
+
+import logging
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+NO_GPU_BATCH_SIZE = 8
+"""What to fall back on with no GPU to probe: enough to make progress, small enough to fit."""
+
+MIN_TRAIN_STEPS_PER_EPOCH = 8
+"""Below this an epoch is one or two optimizer steps, which trains poorly whatever the card."""
+
+
+def find_batch_size(fits: Callable[[int], bool], *, limit: int) -> int:
+    """Return the largest power-of-two batch size that fits, never exceeding ``limit``.
+
+    :param fits: Runs a representative probe; ``False`` on out-of-memory.
+    :raises RuntimeError: If not even a batch size of 1 fits.
+    """
+    limit = smaller_pot(limit)
+    if not fits(1):
+        raise RuntimeError('batch size 1 does not fit in memory')
+
+    size = 1
+    while size < limit and fits(size * 2):
+        size *= 2
+
+    return size
+
+
+def dataset_limit(sample_count: int) -> int:
+    """The batch size ceiling that still leaves ``MIN_TRAIN_STEPS_PER_EPOCH`` steps per epoch."""
+    if sample_count < 1:
+        raise ValueError(f'sample_count must be >= 1, got {sample_count}')
+    return max(1, sample_count // MIN_TRAIN_STEPS_PER_EPOCH)
+
+
+def no_gpu_batch_size(limit: int, probe: str) -> int:
+    """The batch size to fall back on when there is no GPU to probe."""
+    batch_size = min(smaller_pot(limit), NO_GPU_BATCH_SIZE)
+    logger.warning('%s: CUDA is unavailable; using batch size %d without probing', probe, batch_size)
+    return batch_size
+
+
+def smaller_pot(n: int) -> int:
+    """The largest power of two that is <= ``n``."""
+    if n < 1:
+        raise ValueError(f'n must be >= 1, got {n}')
+    return 1 << (n.bit_length() - 1)
+
+
+def batch_count(sample_count: int, batch_size: int) -> int:
+    """How many batches a loader yields, the last one possibly short."""
+    return -(-sample_count // batch_size)
+
+
+def is_out_of_memory(exception: BaseException) -> bool:
+    """Whether the exception signals exhausted memory, on the GPU or the host.
+
+    Allocation failures do not all surface as a framework's dedicated error type: cuDNN and
+    cuBLAS workspaces raise a plain ``RuntimeError``. Catching those by message is what keeps a
+    probe from mistaking a real bug for a full card — a trainer that catches bare
+    ``RuntimeError`` around its probe silently treats every crash as "too big".
+    """
+    if isinstance(exception, MemoryError):
+        return True
+    message = str(exception).lower()
+    return any(text in message for text in ('out of memory', 'alloc_failed', 'cuda error: unknown error'))

--- a/learning_loop_node/trainer/metrics.py
+++ b/learning_loop_node/trainer/metrics.py
@@ -1,0 +1,36 @@
+"""Scoring a training from the confusion matrix the loop stores.
+
+The loop keeps one ``{'tp': .., 'fp': .., 'fn': ..}`` per category, which is what
+``TrainerLogicGeneric._get_new_best_training_state`` returns. Deciding whether an epoch beat
+the previous best means reducing that to one number, and every trainer needs the same one.
+"""
+
+import statistics
+from collections.abc import Mapping
+
+
+def macro_f1(confusion_matrix: Mapping[str, Mapping[str, int]]) -> float:
+    """The unweighted mean of the per-category F1 scores, as the loop's UI shows it by default.
+
+    Unweighted is the point: a rare category the model never finds drags the score down as much
+    as a frequent one, where pooling the counts first would hide it.
+    """
+    scores = [category_f1(counts) for counts in confusion_matrix.values()]
+    return statistics.mean(scores) if scores else 0.0
+
+
+def category_f1(counts: Mapping[str, int]) -> float:
+    """The F1 score of one category, 0.0 where it is undefined rather than a division error."""
+    tp, fp, fn = counts['tp'], counts['fp'], counts['fn']
+    precision = tp / (tp + fp) if tp + fp else 0.0
+    recall = tp / (tp + fn) if tp + fn else 0.0
+    return 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+
+
+def confusion_matrix_from_counts(true_positives: Mapping[str, int], false_positives: Mapping[str, int],
+                                 false_negatives: Mapping[str, int]) -> dict[str, dict[str, int]]:
+    """Assemble the loop's confusion matrix from three per-category count mappings."""
+    return {category: {'tp': true_positives.get(category, 0),
+                       'fp': false_positives.get(category, 0),
+                       'fn': false_negatives.get(category, 0)}
+            for category in {*true_positives, *false_positives, *false_negatives}}

--- a/learning_loop_node/trainer/subprocess.py
+++ b/learning_loop_node/trainer/subprocess.py
@@ -1,0 +1,93 @@
+"""Run a blocking, CPU-bound generator in its own process without blocking the event loop.
+
+A trainer that trains in-process has a problem: the training must not stall the node, and CUDA
+state must stay out of the node process so a crashed training cannot take the node with it.
+:func:`iterator_cpu_bound` runs the generator in a spawned process and yields what it produces
+through a ``maxsize=1`` queue, so the producer can never run more than one item ahead of the
+bookkeeping that consumes it — which is what lets a trainer alternate between two model files
+and know the one it is copying is not being rewritten.
+
+Exceptions raised inside the process are re-raised in the caller, and the process is killed if
+the caller leaves the context early.
+"""
+from __future__ import annotations
+
+import asyncio
+import multiprocessing
+import queue
+import traceback
+from collections.abc import AsyncGenerator, Callable, Iterator
+from contextlib import asynccontextmanager
+from multiprocessing.queues import Queue as MPQueue
+from typing import Any, ParamSpec, TypeVar
+
+T = TypeVar('T')
+P = ParamSpec('P')
+
+
+class IteratorDone:
+    pass
+
+
+def _iterator_wrapper(
+    it: Callable[..., Iterator[T]],
+    state_queue: MPQueue[T | Exception | IteratorDone],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> None:
+    try:
+        for data in it(*args, **kwargs):
+            state_queue.put(data)
+    except Exception as e:
+        print(traceback.format_exc())
+        state_queue.put(e)
+
+    state_queue.put(IteratorDone())
+
+
+async def _iterator_cpu_bound_inner(
+    it: Callable[P, Iterator[T]],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> AsyncGenerator[T, None]:
+    state_queue: MPQueue[T | Exception | IteratorDone] = multiprocessing.Queue(maxsize=1)
+    process = multiprocessing.Process(
+        target=_iterator_wrapper,
+        args=(it, state_queue, args, kwargs),
+        name='iterator_cpu_bound',
+    )
+
+    process.start()
+
+    try:
+        while True:
+            try:
+                item = await asyncio.to_thread(state_queue.get, True, 0.5)
+            except queue.Empty:
+                if not process.is_alive():
+                    break
+                continue
+            match item:
+                case IteratorDone():
+                    break
+                case Exception() as e:
+                    raise e
+                case _ as other:
+                    yield other
+    finally:
+        if process.is_alive():
+            process.kill()
+        process.join()
+
+
+@asynccontextmanager
+async def iterator_cpu_bound(
+    it: Callable[P, Iterator[T]],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> AsyncGenerator[AsyncGenerator[T, None], None]:
+    iterator = _iterator_cpu_bound_inner(it, *args, **kwargs)
+    try:
+        yield iterator
+    finally:
+        await asyncio.shield(iterator.aclose())

--- a/learning_loop_node/trainer/trainer_logic.py
+++ b/learning_loop_node/trainer/trainer_logic.py
@@ -178,9 +178,19 @@ class TrainerLogic(TrainerLogicGeneric):
         '''Is called when self.can_resume() returns True.
         One may resume the training on a previously trained model stored by self.on_model_published(basic_model).'''
 
-    @abstractmethod
     def _get_executor_error_from_log(self) -> Optional[str]:
-        '''Should be used to provide error informations to the Learning Loop by extracting data from self.executor.get_log().'''
+        '''Reports what went wrong to the Learning Loop by reading self.executor's log.
+
+        The default recognises the CUDA failures every trainer hits. Override to add messages a
+        particular training framework produces, and call super() to keep these.'''
+        if self._executor is None:
+            return None
+        for line in self._executor.get_log_by_lines(tail=50):
+            if 'CUDA out of memory' in line:
+                return 'graphics card is out of memory'
+            if 'CUDA error: invalid device ordinal' in line:
+                return 'graphics card not found'
+        return None
 
     @abstractmethod
     async def _detect(self, model_information: ModelInformation, images: List[str], model_folder: str) -> List[Detections]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "python-socketio>=5.16.2,<6.0.0",
     "aiofiles>=0.7.0",
     "python-multipart>=0.0.31",
+    "configargparse>=1.7.1",
     "psutil>=5.9.0,<8.0.0",
     "numpy>=2.0,<3.0",
     "Pillow>=12.3.0,<13.0.0",

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,6 +6,7 @@ set -o allexport; source .env; set +o allexport
 # Check if argument is provided
 if [ $# -eq 1 ]; then
     # Run tests with filter
+    python -m pytest learning_loop_node/tests/unit -v -s -k "$1"
     python -m pytest learning_loop_node/tests/annotator -v -s -k "$1"
     python -m pytest learning_loop_node/tests/detector -v -s -k "$1" 
     python -m pytest learning_loop_node/tests/trainer -v -s -k "$1"
@@ -17,6 +18,8 @@ fi
 
 
 # Run the tests
+# unit runs first: it is the only suite that needs no Learning Loop
+python -m pytest learning_loop_node/tests/unit -v
 python -m pytest learning_loop_node/tests/annotator -v
 python -m pytest learning_loop_node/tests/detector -v
 python -m pytest learning_loop_node/tests/trainer -v

--- a/uv.lock
+++ b/uv.lock
@@ -450,6 +450,15 @@ wheels = [
 ]
 
 [[package]]
+name = "configargparse"
+version = "1.7.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/0b/30328302903c55218ffc5199646d0e9d28348ff26c02ba77b2ffc58d294a/configargparse-1.7.5.tar.gz", hash = "sha256:e3f9a7bb6be34d66b2e3c4a2f58e3045f8dfae47b0dc039f87bcfaa0f193fb0f", size = 53548, upload-time = "2026-03-11T02:19:38.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/19/3ba5e1b0bcc7b91aeab6c258afd70e4907d220fed3972febe38feb40db30/configargparse-1.7.5-py3-none-any.whl", hash = "sha256:1e63fdffedf94da9cd435fc13a1cd24777e76879dd2343912c1f871d4ac8c592", size = 27692, upload-time = "2026-03-11T02:19:36.442Z" },
+]
+
+[[package]]
 name = "dacite"
 version = "1.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -781,6 +790,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
+    { name = "configargparse" },
     { name = "dacite" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -813,6 +823,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=0.7.0" },
     { name = "aiohttp", specifier = ">=3.14.3,<4.0.0" },
     { name = "autopep8", marker = "extra == 'dev'", specifier = ">=2.0.2,<3.0.0" },
+    { name = "configargparse", specifier = ">=1.7.1" },
     { name = "dacite", specifier = ">=1.8.1,<2.0.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.6.7.post1,<2.0.0" },
     { name = "fastapi", specifier = ">=0.135,<1.0" },


### PR DESCRIPTION
## Motivation

Three node repositories build on this library — `dfine_node`, `yolov5_node`, `classification_node` — and a surprising amount of what they contain is not about their models at all. It had been copied between them and had drifted:

- `clip_point` was **byte-identical in five places**. `clip_box` existed in those five plus a sixth that used a **centre-based convention under the same name**, so the function meant two different things depending on the file.
- Confidence filtering, per-class NMS, and building the loop's detection dataclasses existed three to four times over.
- Every `main.py` repeated the same twenty lines of parser-and-uvicorn scaffolding — **eight copies**.
- The confusion-matrix F1 score was implemented three times, over two different data shapes.
- Batch-size selection was implemented three times, three different ways: a real probe, an estimate parsed out of `torchinfo`'s summary *text*, and a doubling loop catching bare `RuntimeError`.
- `_get_executor_error_from_log` was byte-identical in two repositories.

A fourth node would have copied all of it again. This adds the shared home for it, in three commits that are worth reading in order.

## What is added

**`detector/postprocess.py`, `detector/geometry.py`** — `Detection`, `bbox_iou`, `non_max_suppression`, `post_process`, `detections_from_xyxy`, `category_by_index`/`category_by_name`, and one clipping implementation per convention (`clip_box`, `clip_box_centered`, `clip_point`).

The two containers for the same detections are unified: `to_image_metadata` (what a **detector** reports) and `to_detections` (what a **trainer**'s auto-detection pass reports) share one routine, so the two paths can no longer clip and filter differently — which they did.

**`helpers/entrypoint.py`** — `node_parser` and `run_node`. A setting is named after its flag: `--conf-threshold` reads `CONF_THRESHOLD`, and `--help` lists it. `legacy_env_prefix` lets a node that once required a prefix keep reading the old names with a deprecation warning.

`--host`/`--port` are the deliberate exception, reading `NODE_HOST`/`NODE_PORT`. The bare `HOST` already means **the loop's address** — every deployment sets it — so a node deriving it would hand that to uvicorn and fail to bind. There is a test for exactly this.

**`trainer/subprocess.py`, `trainer/batch_size.py`, `trainer/metrics.py`** — `iterator_cpu_bound`, the power-of-two batch-size search, and `macro_f1`. The batch-size search **imports no framework**: it is pure arithmetic around a `fits` predicate the trainer supplies, which is what lets any node use it. `is_out_of_memory` is part of that: allocation failures do not all arrive as a dedicated error type — cuDNN and cuBLAS raise plain `RuntimeError` — and one repository was catching bare `RuntimeError`, so every crash looked like a full card.

**`TrainerLogic._get_executor_error_from_log`** gains a default implementation and stops being abstract; existing overrides keep working.

## Testing

Adds **`learning_loop_node/tests/unit/`, the first suite that runs without a Learning Loop** — no credentials, no network, 197 tests in about 1.5 seconds. CI gates the credential-dependent jobs on it.

That gap is why the node repositories have so few tests: `learning_loop_node/tests/` is excluded from the wheel, so nothing in it is importable downstream. Making the helpers shippable is a follow-up phase; this establishes the suite.

## A disagreeing environment variable no longer points at production

`read_from_env` takes an ordered list of names — `['LOOP_HOST', 'HOST']` and so on — and returned `None` when two were set to **different** values. The caller then fell back to its default, and `host()`'s default is `'learning-loop.ai'`. So a `.env` carrying both spellings with different values pointed the node at **production**, with only a log warning.

Since `values` is built in `possible_names` order and then filtered, the first surviving value is already the preferred one — so the fix is to warn and fall through to the existing `return values[0]`. `ignore_errors=False` still raises.

This is the right layer for it: the node repositories' `docker.sh` scripts had been working around it by forwarding exactly one spelling, which forced every sub-project to agree on which. Now that the container receives the whole `.env`, only the library can decide. Six tests added in `tests/unit/test_environment_reader.py`.

## Notes for the reviewer

- **`post_process` still truncates box corners with `int()`** so detector output stays bit-identical to before. `detections_from_xyxy` rounds instead, matching the trainer code it replaces. The difference is deliberate and documented.
- The PEP 695 type parameters (`def f[T]`) in the moved generator were rewritten as `TypeVar`/`ParamSpec`: this library supports **Python 3.10** while `dfine_node` targets 3.12. Verified by CI on both 3.10 and 3.13.
- The `logging.basicConfig(...)` every trainer carries is not reproduced. `helpers/log_conf.py` configures the root logger at import, so `basicConfig` has been a no-op — checked, not assumed.
- No node consumes this yet; the node PRs are separate and stay pinned to `0.21.0` until this is released.

## Deliberately not included

- **`SubprocessTrainerLogic`**, a third trainer base class. With `dfine_node` as the only consumer its progress protocol would be invented from one example, and `yolov5_node`'s executor-and-log-scraping shape may not fit it.
- **`cuda.py`** (`free_cuda_memory`, `usable_memory_bytes`, `limit_cuda_memory`). These need torch, which would mean an optional extra and a module this repository's CI cannot exercise. Left in `dfine_node` until a second node wants them.

---
⬛ claude-opus-5[1m] · 700k tokens · $16.90